### PR TITLE
Fix another schema error

### DIFF
--- a/data/engrampa.convert
+++ b/data/engrampa.convert
@@ -43,7 +43,7 @@ default-extension = /org/mate/engrampa/dialogs/batch-add/default_extension
 other-options = /org/mate/engrampa/dialogs/batch-add/other_options
 volume-size = /org/mate/engrampa/dialogs/batch-add/volume_size
 
-[org.gnome.engrampa.dialogs.last-output]
+[org.mate.engrampa.dialogs.last-output]
 width = /org/mate/engrampa/dialogs/last_output/width
 height = /org/mate/engrampa/dialogs/last_output/height
 


### PR DESCRIPTION
test_level = <optimized out>
        was_fatal = <optimized out>
        was_recursion = <optimized out>
        msg = 0x20c28f0 "Settings schema 'org.gnome.engrampa.dialogs.lastoutput' is not installed\n"
        msg_alloc = 0x20c28f0 "Settings schema 'org.gnome.engrampa.dialogs.lastoutput' is not installed\n"
        i = 2
