### PR TITLE
Fix for the missing schema issue 19

### DIFF
--- a/data/org.mate.engrampa.gschema.xml.in
+++ b/data/org.mate.engrampa.gschema.xml.in
@@ -148,15 +148,6 @@
       <default>true</default>
       <summary>Recreate the folders stored in the archive</summary>
     </key>
-    <key name="update" type="b">
-      <default>false</default>
-    </key>
-    <key name="recursive" type="b">
-      <default>true</default>
-    </key>
-    <key name="no-symlinks" type="b">
-      <default>false</default>
-    </key>
   </schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.engrampa.dialogs.add" path="/org/mate/engrampa/dialogs/add/">
     <key name="current-folder" type="s">
@@ -174,7 +165,16 @@
     <key name="exclude-folders" type="s">
       <default>''</default>
     </key>
-  </schema>
+    <key name="update" type="b">
+      <default>false</default>
+    </key>
+    <key name="recursive" type="b">
+      <default>true</default>
+    </key>
+    <key name="no-symlinks" type="b">
+      <default>false</default>
+    </key>
+</schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.engrampa.dialogs.batch-add" path="/org/mate/engrampa/dialogs/batch-add/">
     <key name="default-extension" type="s">
       <default>'.tar.gz'</default>


### PR DESCRIPTION
The keys update, recursive and no-symlinks are in the wrong schema,
in org.mate.engrampa.dialogs.extract instead of org.mate.engrampa.dialogs.add

Fixes https://github.com/mate-desktop/mate-file-archiver/issues/19
