### PR TITLE
Make Caja GSettings schema optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ dnl it too, or it will never make it into the spec file!
 dnl
 dnl ==========================================================================
 
-GLIB_REQUIRED=2.25.5
+GLIB_REQUIRED=2.32.0
 GIO_REQUIRED=2.25.5
 CAJA_REQUIRED=1.1.0
 JSON_GLIB_REQUIRED=0.14.0

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -4607,6 +4607,9 @@ is_single_click_policy (FrWindow *window)
 	char     *value;
 	gboolean  result;
 
+	if (window->priv->settings_caja == NULL)
+		return FALSE;
+
 	value = g_settings_get_string (window->priv->settings_caja, CAJA_CLICK_POLICY);
 	result = (value != NULL) && (strncmp (value, "single", 6) == 0);
 	g_free (value);
@@ -5391,6 +5394,8 @@ fr_window_construct (FrWindow *window)
 	GtkToolItem      *open_recent_tool_item;
 	GtkWidget        *menu_item;
 	GError           *error = NULL;
+	GSettingsSchemaSource *source;
+	GSettingsSchema *schema;
 
 	/* data common to all windows. */
 
@@ -5408,7 +5413,9 @@ fr_window_construct (FrWindow *window)
 	window->priv->settings_ui = g_settings_new (ENGRAMPA_SCHEMA_UI);
 	window->priv->settings_general = g_settings_new (ENGRAMPA_SCHEMA_GENERAL);
 	window->priv->settings_dialogs = g_settings_new (ENGRAMPA_SCHEMA_DIALOGS);
-	window->priv->settings_caja = g_settings_new (CAJA_SCHEMA);
+
+	source = g_settings_schema_source_get_default ();
+	schema = g_settings_schema_source_lookup (source, CAJA_SCHEMA, TRUE);
 
 	/* Create the application. */
 
@@ -6010,7 +6017,8 @@ fr_window_construct (FrWindow *window)
 			"changed::" PREF_LISTING_USE_MIME_ICONS,
 			G_CALLBACK (pref_use_mime_icons_changed),
 			window);
-	g_signal_connect (window->priv->settings_caja,
+	if (window->priv->settings_caja)
+			g_signal_connect (window->priv->settings_caja,
 			"changed::" CAJA_CLICK_POLICY,
 			G_CALLBACK (pref_click_policy_changed),
 			window);


### PR DESCRIPTION
This make the caja schema optional (so that engrampa can be used without caja installed), fixing the
"GLib-GIO-ERROR **: Settings schema 'org.mate.caja.preferences' is not installed" error if caja isn't present (taken and adapted from file-roller)
