### PR TITLE
GTK3: set top and bottom margin of statusbar to zero

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -5983,6 +5983,13 @@ fr_window_construct (FrWindow *window)
 	window->priv->progress_cid = gtk_statusbar_get_context_id (GTK_STATUSBAR (window->priv->statusbar), "progress");
 
 	statusbar = GTK_STATUSBAR (window->priv->statusbar);
+
+	/*reduce size of statusbar */
+#if GTK_CHECK_VERSION (3, 0, 0)
+	gtk_widget_set_margin_top (GTK_WIDGET (statusbar), 0);
+	gtk_widget_set_margin_bottom (GTK_WIDGET (statusbar), 0);
+#endif
+
 	statusbar_box = gtk_statusbar_get_message_area (statusbar);
 	gtk_box_set_homogeneous (GTK_BOX (statusbar_box), FALSE);
 	gtk_box_set_spacing (GTK_BOX (statusbar_box), 4);


### PR DESCRIPTION
This reduce the size of the statusbar that it looks like GTK2 version.
The size can now controled with .frame.flat and/or .flat.button selector
by the theme.