### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -79,3 +79,9 @@
   ./autogen.sh
   make
   make install
+
+* Notes
+
+  [Read-only mode] means that Engrampa may read the file type, but it cannot write to that file type.  
+  An example is ISO-9660 CD Disc Image (.iso) [Read-only mode].  Iso images may be read, but file(s) cannot be
+  written to an (.iso).


### PR DESCRIPTION
* Notes

  [Read-only mode] means that Engrampa may read the file type, but it cannot write to that file type.  
  An example is ISO-9660 CD Disc Image (.iso) [Read-only mode].  ISO images may be read, but
  file(s) cannot be written to an (.iso).