### PR TITLE
fr-command-rar: additional check for NULL pointer to avoid crash

### DIFF
--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -152,6 +152,9 @@ parse_name_field (char         *line,
 	else
 		name_field = g_strdup (line + 1);
 
+	if (name_field == NULL)
+		return;
+
 	if (*name_field == '/') {
 		fdata->full_path = g_strdup (name_field);
 		fdata->original_path = fdata->full_path;


### PR DESCRIPTION
adapted from
https://github.com/GNOME/file-roller/commit/8c55a4118dc83f171ca89407492269ecfe0a20d3