### PR TITLE
fixed overwrite check when the files to be extracted are inside a folder

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -6742,14 +6742,16 @@ _fr_window_ask_overwrite_dialog (OverwriteData *odata)
 	gboolean do_not_extract = FALSE;
 
 	while ((odata->edata->overwrite == FR_OVERWRITE_ASK) && (odata->current_file != NULL)) {
-		char      *path;
-		char      *dest_uri;
-		GFile     *file;
-		GFileInfo *info;
-		GFileType  file_type;
+		const char *base_name;
+		char       *e_base_name;
+		char       *dest_uri;
+		GFile      *file;
+		GFileInfo  *info;
+		GFileType   file_type;
 
-		path = g_uri_escape_string ((char *) odata->current_file->data, G_URI_RESERVED_CHARS_ALLOWED_IN_PATH, TRUE);
-		dest_uri = g_strdup_printf ("%s/%s", odata->edata->extract_to_dir, path);
+		base_name = _g_path_get_base_name ((char *) odata->current_file->data, odata->edata->base_dir, odata->edata->junk_paths);
+		e_base_name = g_uri_escape_string (base_name, G_URI_RESERVED_CHARS_ALLOWED_IN_PATH, TRUE);
+		dest_uri = g_strdup_printf ("%s/%s", odata->edata->extract_to_dir, e_base_name);
 		file = g_file_new_for_uri (dest_uri);
 		info = g_file_query_info (file,
 					  G_FILE_ATTRIBUTE_STANDARD_TYPE "," G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_DISPLAY_NAME,
@@ -6758,7 +6760,7 @@ _fr_window_ask_overwrite_dialog (OverwriteData *odata)
 					  NULL);
 
 		g_free (dest_uri);
-		g_free (path);
+		g_free (e_base_name);
 
 		if (info == NULL) {
 			g_object_unref (file);
@@ -6802,6 +6804,8 @@ _fr_window_ask_overwrite_dialog (OverwriteData *odata)
 
 			return;
 		}
+		else
+			odata->current_file = odata->current_file->next;
 
 		g_object_unref (info);
 		g_object_unref (file);

--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -713,3 +713,51 @@ _g_strv_remove (char **str_array,
         return TRUE;
 }
 
+
+const gchar *
+_g_path_get_file_name (const gchar *file_name)
+{
+	register char   *base;
+	register gssize  last_char;
+
+	if (file_name == NULL)
+		return NULL;
+
+	if (file_name[0] == '\0')
+		return "";
+
+	last_char = strlen (file_name) - 1;
+
+	if (file_name [last_char] == G_DIR_SEPARATOR)
+		return "";
+
+	base = g_utf8_strrchr (file_name, -1, G_DIR_SEPARATOR);
+	if (! base)
+		return file_name;
+
+	return base + 1;
+}
+
+
+const char *
+_g_path_get_base_name (const char *path,
+		       const char *base_dir,
+		       gboolean    junk_paths)
+{
+	int         base_dir_len;
+	const char *base_path;
+
+	if (junk_paths)
+		return _g_path_get_file_name (path);
+
+	base_dir_len = strlen (base_dir);
+	if (strlen (path) <= base_dir_len)
+		return NULL;
+
+	base_path = path + base_dir_len;
+	if (path[0] != '/')
+		base_path -= 1;
+
+	return base_path;
+}
+

--- a/src/glib-utils.h
+++ b/src/glib-utils.h
@@ -80,6 +80,9 @@ char **            _g_strv_prepend               (char **str_array,
                                                   const char *str);
 gboolean           _g_strv_remove                (char **str_array,
                                                   const char *str);
+
+/* path filename */
+
 const char *        _g_path_get_file_name          (const char          *path);
 const char *        _g_path_get_base_name          (const char          *path,
 						    const char          *base_dir,

--- a/src/glib-utils.h
+++ b/src/glib-utils.h
@@ -80,6 +80,10 @@ char **            _g_strv_prepend               (char **str_array,
                                                   const char *str);
 gboolean           _g_strv_remove                (char **str_array,
                                                   const char *str);
+const char *        _g_path_get_file_name          (const char          *path);
+const char *        _g_path_get_base_name          (const char          *path,
+						    const char          *base_dir,
+						    gboolean             junk_paths);
 
 /**/
 


### PR DESCRIPTION
Fixes #103 

the commit in file-roller:

https://git.gnome.org/browse/file-roller/commit/?id=a1e641aa423b95e7a0b84f7a63bec6efc4fb3257