### PR TITLE
Let's add some parallelism to engrampa

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -4,12 +4,9 @@
   an entry in po/ChangeLog
 
 *Patches
-
-  Send patches to the maintainer (engrampa-maint@gnome.org) and get 
-  approval before committing.
-
-  Patches must contain a ChangeLog entry.
-
+  
+  Fork and send Pull Requests to github.com/mate-desktop/enrampa.
+  
   You have to follow the style of the rest of the code even if you 
   don't like it.  The code style is K&R with 8 space tabs.
 

--- a/HACKING
+++ b/HACKING
@@ -5,7 +5,7 @@
 
 *Patches
   
-  Fork and send Pull Requests to github.com/mate-desktop/enrampa.
+  Fork and send Pull Requests to github.com/mate-desktop/engrampa.
   
   You have to follow the style of the rest of the code even if you 
   don't like it.  The code style is K&R with 8 space tabs.

--- a/configure.ac
+++ b/configure.ac
@@ -217,6 +217,22 @@ AM_CONDITIONAL(ENABLE_MAGIC, test x"$enable_magic" != x"no")
 
 dnl ******************************
 
+dnl ******************************
+
+AC_ARG_ENABLE([pixz],
+              AS_HELP_STRING([--enable-pixz], [use pixz to extract xz archives]),,
+              [enable_pixz=no])
+
+if test x"$enable_pixz" = x"yes" ; then
+	AC_MSG_CHECKING([whether pixz binary found])
+	AC_CHECK_PROG(ENABLE_PIXZ, "pixz", "yes")
+	AC_DEFINE(ENABLE_PIXZ, 1, [define to enable pixz])
+fi
+
+AM_CONDITIONAL(ENABLE_PIXZ, test x"$enable_pixz" != x"no")
+
+dnl ******************************
+
 YELP_HELP_INIT
 
 dnl ******************************
@@ -268,4 +284,5 @@ Configuration:
 	Run in place            ${enable_run_in_place}
 	Use libmagic:           ${enable_magic}
 	JSON support:           ${enable_json_glib}
+	PIXZ support:           ${enable_pixz}
 "

--- a/src/fr-command-tar.c
+++ b/src/fr-command-tar.c
@@ -216,7 +216,11 @@ add_compress_arg (FrCommand *comm)
 		fr_process_add_arg (comm->process, "--use-compress-program=lzma");
 
 	else if (is_mime_type (comm->mime_type, "application/x-xz-compressed-tar"))
+#if ENABLE_PIXZ
+		fr_process_add_arg (comm->process, "--use-compress-program=pixz");
+#else
 		fr_process_add_arg (comm->process, "--use-compress-program=xz");
+#endif
 
 	else if (is_mime_type (comm->mime_type, "application/x-lzop-compressed-tar"))
 		fr_process_add_arg (comm->process, "--use-compress-program=lzop");


### PR DESCRIPTION
I'd like to add support for parallel programs in engrampa. Most of the utils working with tar have a mulitcore implementation which is faster. This really cool if you can do in the command line the following:
``` 
tar -Ipixz -xvf file.tar.xz 
```
instead of 
```
tar xvJf file.tar.xz
```
The first command will utilize all cores on the machine and will run significantly faster.
Most machines sold today (and in the last years even) are multi-core, even simple boards like the raspberrypi. So why limit only CLI users and power users to that? 

This patch allows to build engrampa with the following option:
```
./configure --enable-pixz
make
make install
```
Now files with xz compression will be extracted with pixz instead of xz binary.

I intend to add a series of patches to enable parallel extraction to all the possible backends (read: where a good free implementation is packaged and found). 

This would be a humble start. After that we could think of : 
- parallel compressing,
- modifying the GUI to enable fine control (e.g. max CPUS used for extraction\compression)
- instead of build time option, user (not packager) ability to choose between parallel and conventional compression program (pixz\xz for example). 

I would be happy to hear your feedback about this. If the feedback is positive, I will go a head an add the other parallel options to the code (e.g. bz2, gunzip etc.)