### PR TITLE
Give unrar priority over p7zip

### DIFF
--- a/src/fr-init.c
+++ b/src/fr-init.c
@@ -342,6 +342,7 @@ register_commands (void)
 
 	register_command (FR_TYPE_COMMAND_TAR);
 	register_command (FR_TYPE_COMMAND_CFILE);
+	register_command (FR_TYPE_COMMAND_RAR);
 	register_command (FR_TYPE_COMMAND_7Z);
 	register_command (FR_TYPE_COMMAND_DPKG);
 
@@ -353,7 +354,6 @@ register_commands (void)
 	register_command (FR_TYPE_COMMAND_ISO);
 	register_command (FR_TYPE_COMMAND_JAR);
 	register_command (FR_TYPE_COMMAND_LHA);
-	register_command (FR_TYPE_COMMAND_RAR);
 	register_command (FR_TYPE_COMMAND_RPM);
 	register_command (FR_TYPE_COMMAND_UNSTUFF);
 	register_command (FR_TYPE_COMMAND_ZIP);


### PR DESCRIPTION
At the moment p7zip does not support RAR5 archives, so reading such archives will always fail.