### PR TITLE
fix extracting files with single-character names. #125

### DIFF
--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -2911,7 +2911,7 @@ compute_base_path (const char *base_dir,
 		return new_path;
 	}
 
-	if (path_len <= base_dir_len)
+	if (path_len < base_dir_len)
 		return NULL;
 
 	base_path = path + base_dir_len;

--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -751,7 +751,7 @@ _g_path_get_base_name (const char *path,
 		return _g_path_get_file_name (path);
 
 	base_dir_len = strlen (base_dir);
-	if (strlen (path) <= base_dir_len)
+	if (strlen (path) < base_dir_len)
 		return NULL;
 
 	base_path = path + base_dir_len;


### PR DESCRIPTION
The patch on file-roller:

https://bugzilla.gnome.org/show_bug.cgi?id=761582

Fixes #125