### PR TITLE
tar: Fixed problems with backslashes

### DIFF
--- a/src/fr-command-tar.c
+++ b/src/fr-command-tar.c
@@ -331,6 +331,7 @@ fr_command_tar_add (FrCommand     *comm,
 	if (! recursive)
 		fr_process_add_arg (comm->process, "--no-recursion");
 	fr_process_add_arg (comm->process, "--no-wildcards");
+	fr_process_add_arg (comm->process, "--no-unquote");
 	fr_process_add_arg (comm->process, "-v");
 	fr_process_add_arg (comm->process, "-p");
 
@@ -401,6 +402,7 @@ fr_command_tar_delete (FrCommand  *comm,
 	fr_process_set_begin_func (comm->process, begin_func__delete, comm);
 	fr_process_add_arg (comm->process, "--force-local");
 	fr_process_add_arg (comm->process, "--no-wildcards");
+	fr_process_add_arg (comm->process, "--no-unquote");
 	fr_process_add_arg (comm->process, "-v");
 	fr_process_add_arg (comm->process, "--delete");
 	fr_process_add_arg (comm->process, "-f");
@@ -448,6 +450,7 @@ fr_command_tar_extract (FrCommand  *comm,
 	begin_tar_command (comm);
 	fr_process_add_arg (comm->process, "--force-local");
 	fr_process_add_arg (comm->process, "--no-wildcards");
+	fr_process_add_arg (comm->process, "--no-unquote");
 	fr_process_add_arg (comm->process, "-v");
 	fr_process_add_arg (comm->process, "-p");
 


### PR DESCRIPTION
Fixes #79

using --no-unquote
do not unquote input file or member names