### PR TITLE
require GTK+ >= 3.14, drop GTK+2 code and --with-gtk build option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,27 +30,9 @@ dnl ==========================================================================
 
 GLIB_REQUIRED=2.32.0
 GIO_REQUIRED=2.25.5
+GTK_REQUIRED=3.14.0
 CAJA_REQUIRED=1.1.0
 JSON_GLIB_REQUIRED=0.14.0
-
-AC_MSG_CHECKING([which gtk+ version to compile against])
-AC_ARG_WITH([gtk],
-  [AS_HELP_STRING([--with-gtk=2.0|3.0],[which gtk+ version to compile against (default: 2.0)])],
-  [case "$with_gtk" in
-     2.0|3.0) ;;
-     *) AC_MSG_ERROR([invalid gtk version specified]) ;;
-   esac],
-  [with_gtk=2.0])
-AC_MSG_RESULT([$with_gtk])
-
-case "$with_gtk" in
-  2.0) GTK_API_VERSION=2.0
-       GTK_REQUIRED=2.24.0
-       ;;
-  3.0) GTK_API_VERSION=3.0
-       GTK_REQUIRED=3.0.2
-       ;;
-esac
 
 AC_SUBST(GLIB_REQUIRED)
 AC_SUBST(GIO_REQUIRED)
@@ -59,7 +41,7 @@ AC_SUBST(CAJA_REQUIRED)
 
 dnl ===========================================================================
 
-PKG_CHECK_MODULES(GTK, [gtk+-$GTK_API_VERSION >= $GTK_REQUIRED])
+PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= $GTK_REQUIRED])
 AC_SUBST([GTK_CFLAGS])
 AC_SUBST([GTK_LIBS])
 
@@ -97,7 +79,7 @@ PKG_CHECK_MODULES(FR,					\
 	glib-2.0 >= $GLIB_REQUIRED			\
 	gthread-2.0					\
 	gio-unix-2.0 >= $GIO_REQUIRED			\
-	gtk+-$GTK_API_VERSION >= $GTK_REQUIRED)
+	gtk+-3.0 >= $GTK_REQUIRED)
 AC_SUBST(FR_CFLAGS)
 AC_SUBST(FR_LIBS)
 

--- a/copy-n-paste/eggsmclient-xsmp.c
+++ b/copy-n-paste/eggsmclient-xsmp.c
@@ -368,13 +368,7 @@ sm_client_xsmp_startup (EggSMClient *client,
       xsmp->client_id = g_strdup (ret_client_id);
       free (ret_client_id);
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-      gdk_threads_enter ();
-#endif
       gdk_x11_set_sm_client_id (xsmp->client_id);
-#if !GTK_CHECK_VERSION (3, 0, 0)
-      gdk_threads_leave ();
-#endif
       g_debug ("Got client ID \"%s\"", xsmp->client_id);
     }
 
@@ -541,10 +535,6 @@ idle_do_pending_events (gpointer data)
   EggSMClientXSMP *xsmp = data;
   EggSMClient *client = data;
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_enter ();
-#endif
-
   xsmp->idle = 0;
 
   if (xsmp->waiting_to_emit_quit)
@@ -568,9 +558,6 @@ idle_do_pending_events (gpointer data)
     }
 
  out:
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_leave ();
-#endif
   return FALSE;
 }
 
@@ -1292,13 +1279,7 @@ process_ice_messages (IceConn ice_conn)
 {
   IceProcessMessagesStatus status;
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_enter ();
-#endif
   status = IceProcessMessages (ice_conn, NULL, NULL);
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gdk_threads_leave ();
-#endif
 
   switch (status)
     {

--- a/src/dlg-add-files.c
+++ b/src/dlg-add-files.c
@@ -32,10 +32,6 @@
 #include "preferences.h"
 #include "dlg-add-files.h"
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-#define gtk_hbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL, Y)
-#endif
-
 typedef struct {
 	FrWindow  *window;
 	GSettings *settings;
@@ -171,7 +167,7 @@ add_files_cb (GtkWidget *widget,
 	 * newer than the archive version. */
 	data->add_if_newer_checkbutton = gtk_check_button_new_with_mnemonic (_("Add only if _newer"));
 
-	main_box = gtk_hbox_new (FALSE, 20);
+	main_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 20);
 	gtk_container_set_border_width (GTK_CONTAINER (main_box), 0);
 	gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER (file_sel), main_box);
 

--- a/src/dlg-add-folder.c
+++ b/src/dlg-add-folder.c
@@ -40,11 +40,6 @@
 #define UNUSED_VARIABLE
 #endif
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-#define gtk_vbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_VERTICAL, Y)
-#define gtk_hbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL, Y)
-#endif
-
 typedef struct {
 	FrWindow    *window;
 	GSettings   *settings;
@@ -266,11 +261,11 @@ add_folder_cb (GtkWidget *widget,
 	data->save_button = gtk_button_new_with_mnemonic (_("Sa_ve Options"));
 	data->clear_button = gtk_button_new_with_mnemonic (_("_Reset Options"));
 
-	main_box = gtk_hbox_new (FALSE, 20);
+	main_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 20);
 	gtk_container_set_border_width (GTK_CONTAINER (main_box), 0);
 	gtk_file_chooser_set_extra_widget (GTK_FILE_CHOOSER (file_sel), main_box);
 
-	vbox = gtk_vbox_new (FALSE, 6);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 0);
 	gtk_box_pack_start (GTK_BOX (main_box), vbox, TRUE, TRUE, 0);
 
@@ -330,7 +325,7 @@ add_folder_cb (GtkWidget *widget,
 
 	/**/
 
-	vbox = gtk_vbox_new (FALSE, 5);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 0);
 	gtk_box_pack_start (GTK_BOX (main_box), vbox, FALSE, FALSE, 0);
 

--- a/src/dlg-extract.c
+++ b/src/dlg-extract.c
@@ -32,11 +32,6 @@
 #include "typedefs.h"
 #include "dlg-extract.h"
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-#define gtk_vbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_VERTICAL, Y)
-#define gtk_hbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL, Y)
-#endif
-
 typedef struct {
 	FrWindow     *window;
 	GSettings    *settings;
@@ -325,13 +320,13 @@ create_extra_widget (DialogData *data)
 	GtkWidget *label48;
 	GtkWidget *vbox15;
 
-	vbox1 = gtk_vbox_new (FALSE, 6);
+	vbox1 = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox1), 0);
 
-	hbox28 = gtk_hbox_new (FALSE, 12);
+	hbox28 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
 	gtk_box_pack_start (GTK_BOX (vbox1), hbox28, TRUE, TRUE, 0);
 
-	vbox19 = gtk_vbox_new (FALSE, 6);
+	vbox19 = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (hbox28), vbox19, TRUE, TRUE, 0);
 
 	e_files_label = gtk_label_new ("");
@@ -340,7 +335,7 @@ create_extra_widget (DialogData *data)
 	gtk_label_set_justify (GTK_LABEL (e_files_label), GTK_JUSTIFY_LEFT);
 	gtk_misc_set_alignment (GTK_MISC (e_files_label), 0, 0.5);
 
-	hbox29 = gtk_hbox_new (FALSE, 0);
+	hbox29 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (vbox19), hbox29, TRUE, TRUE, 0);
 
 	label47 = gtk_label_new ("    ");
@@ -380,7 +375,7 @@ create_extra_widget (DialogData *data)
 	gtk_radio_button_set_group (GTK_RADIO_BUTTON (data->e_selected_radiobutton), e_files_radiobutton_group);
 	e_files_radiobutton_group = gtk_radio_button_get_group (GTK_RADIO_BUTTON (data->e_selected_radiobutton));
 
-	vbox20 = gtk_vbox_new (FALSE, 6);
+	vbox20 = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (hbox28), vbox20, TRUE, TRUE, 0);
 
 	e_actions_label = gtk_label_new ("");
@@ -390,14 +385,14 @@ create_extra_widget (DialogData *data)
 	gtk_label_set_justify (GTK_LABEL (e_actions_label), GTK_JUSTIFY_LEFT);
 	gtk_misc_set_alignment (GTK_MISC (e_actions_label), 0, 0.5);
 
-	hbox30 = gtk_hbox_new (FALSE, 0);
+	hbox30 = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start (GTK_BOX (vbox20), hbox30, TRUE, TRUE, 0);
 
 	label48 = gtk_label_new ("    ");
 	gtk_box_pack_start (GTK_BOX (hbox30), label48, FALSE, FALSE, 0);
 	gtk_label_set_justify (GTK_LABEL (label48), GTK_JUSTIFY_LEFT);
 
-	vbox15 = gtk_vbox_new (FALSE, 6);
+	vbox15 = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_box_pack_start (GTK_BOX (hbox30), vbox15, TRUE, TRUE, 0);
 
 	data->e_recreate_dir_checkbutton = gtk_check_button_new_with_mnemonic (_("Re-crea_te folders"));

--- a/src/dlg-new.c
+++ b/src/dlg-new.c
@@ -360,10 +360,7 @@ dlg_new_archive (FrWindow  *window,
 	egg_file_format_chooser_set_format (data->format_chooser, 0);
 	gtk_widget_show (GTK_WIDGET (data->format_chooser));
 	gtk_box_pack_start (GTK_BOX (GET_WIDGET ("format_chooser_box")), GTK_WIDGET (data->format_chooser), TRUE, TRUE, 0);
-
-#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_set_vexpand (GET_WIDGET ("extra_widget"), FALSE);
-#endif
 
 	/* Set the signals handlers. */
 

--- a/src/dlg-package-installer.c
+++ b/src/dlg-package-installer.c
@@ -171,11 +171,7 @@ install_packages (InstallerData *idata)
 			display = gtk_widget_get_display (GTK_WIDGET (idata));
 			cursor = gdk_cursor_new_for_display (display, GDK_WATCH);
 			gdk_window_set_cursor (window, cursor);
-#if GTK_CHECK_VERSION (3, 0, 0)
 			g_object_unref (cursor);
-#else
-			gdk_cursor_unref (cursor);
-#endif
 		}
 
 		proxy = g_dbus_proxy_new_sync (connection,

--- a/src/eggfileformatchooser.c
+++ b/src/eggfileformatchooser.c
@@ -413,9 +413,6 @@ egg_file_format_chooser_init (EggFileFormatChooser *self)
 
   view = gtk_tree_view_new_with_model (GTK_TREE_MODEL (self->priv->model));
   self->priv->selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (view));
-#if !GTK_CHECK_VERSION (3, 0, 0)
-  gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (view), TRUE);
-#endif
 
 /* file format column */
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -100,12 +100,6 @@ static int             dir_tree_icon_size = 0;
 #define FR_CLIPBOARD (gdk_atom_intern_static_string ("_RNGRAMPA_SPECIAL_CLIPBOARD"))
 #define FR_SPECIAL_URI_LIST (gdk_atom_intern_static_string ("application/engrampa-uri-list"))
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-#define gtk_hpaned_new() gtk_paned_new(GTK_ORIENTATION_HORIZONTAL)
-#define gtk_vbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_VERTICAL, Y)
-#define gtk_hbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL, Y)
-#endif
-
 static GtkTargetEntry clipboard_targets[] = {
 	{ "application/engrampa-uri-list", 0, 1 }
 };
@@ -2527,7 +2521,7 @@ create_the_progress_dialog (FrWindow *window)
 
 	/* Main */
 
-	hbox = gtk_hbox_new (FALSE, 24);
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 24);
 	gtk_container_set_border_width (GTK_CONTAINER (hbox), 6);
 	gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (d)), hbox, FALSE, FALSE, 10);
 
@@ -2538,7 +2532,7 @@ create_the_progress_dialog (FrWindow *window)
 	gtk_misc_set_alignment (GTK_MISC (window->priv->pd_icon), 0.5, 0.0);
 	gtk_box_pack_start (GTK_BOX (hbox), window->priv->pd_icon, FALSE, FALSE, 0);
 
-	vbox = gtk_vbox_new (FALSE, 5);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 5);
 	gtk_box_pack_start (GTK_BOX (hbox), vbox, TRUE, TRUE, 0);
 
 	/* action description */
@@ -2568,7 +2562,7 @@ create_the_progress_dialog (FrWindow *window)
 	align = gtk_alignment_new (0.0, 0.0, 1.0, 1.0);
 	gtk_alignment_set_padding (GTK_ALIGNMENT (align), 0, 6, 0, 0);
 
-	progress_vbox = gtk_vbox_new (FALSE, 6);
+	progress_vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_container_add (GTK_CONTAINER (align), progress_vbox);
 	gtk_box_pack_start (GTK_BOX (vbox), align, TRUE, TRUE, 0);
 
@@ -5636,9 +5630,6 @@ fr_window_construct (FrWindow *window)
 	g_object_set_data (G_OBJECT (window->priv->list_store), "FrWindow", window);
 	window->priv->list_view = gtk_tree_view_new_with_model (GTK_TREE_MODEL (window->priv->list_store));
 
-#if !GTK_CHECK_VERSION (3, 0, 0)
-	gtk_tree_view_set_rules_hint (GTK_TREE_VIEW (window->priv->list_view), TRUE);
-#endif
 	add_file_list_columns (window, GTK_TREE_VIEW (window->priv->list_view));
 	gtk_tree_view_set_enable_search (GTK_TREE_VIEW (window->priv->list_view),
 					 TRUE);
@@ -5717,7 +5708,7 @@ fr_window_construct (FrWindow *window)
 
 	/* filter bar */
 
-	window->priv->filter_bar = filter_box = gtk_hbox_new (FALSE, 6);
+	window->priv->filter_bar = filter_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 	gtk_container_set_border_width (GTK_CONTAINER (filter_box), 3);
 	fr_window_attach (FR_WINDOW (window), window->priv->filter_bar, FR_WINDOW_AREA_FILTERBAR);
 
@@ -5793,12 +5784,12 @@ fr_window_construct (FrWindow *window)
 
 	/* side pane */
 
-	window->priv->sidepane = gtk_vbox_new (FALSE, 0);
+	window->priv->sidepane = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 
 	sidepane_title = gtk_frame_new (NULL);
 	gtk_frame_set_shadow_type (GTK_FRAME (sidepane_title), GTK_SHADOW_ETCHED_IN);
 
-	sidepane_title_box = gtk_hbox_new (FALSE, 0);
+	sidepane_title_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_container_set_border_width (GTK_CONTAINER (sidepane_title_box), 2);
 	gtk_container_add (GTK_CONTAINER (sidepane_title), sidepane_title_box);
 	sidepane_title_label = gtk_label_new (_("Folders"));
@@ -5821,7 +5812,7 @@ fr_window_construct (FrWindow *window)
 
 	/* main content */
 
-	window->priv->paned = gtk_hpaned_new ();
+	window->priv->paned = gtk_paned_new (GTK_ORIENTATION_HORIZONTAL);
 	gtk_paned_pack1 (GTK_PANED (window->priv->paned), window->priv->sidepane, FALSE, TRUE);
 	gtk_paned_pack2 (GTK_PANED (window->priv->paned), list_scrolled_window, TRUE, TRUE);
 	gtk_paned_set_position (GTK_PANED (window->priv->paned), g_settings_get_int (window->priv->settings_ui, PREF_UI_SIDEBAR_WIDTH));
@@ -5915,9 +5906,7 @@ fr_window_construct (FrWindow *window)
 
 	window->priv->toolbar = toolbar = gtk_ui_manager_get_widget (ui, "/ToolBar");
 	gtk_toolbar_set_show_arrow (GTK_TOOLBAR (toolbar), TRUE);
-#if GTK_CHECK_VERSION(3,0,0)
 	gtk_style_context_add_class (gtk_widget_get_style_context (toolbar), GTK_STYLE_CLASS_PRIMARY_TOOLBAR);
-#endif
 	set_action_important (ui, "/ToolBar/Extract_Toolbar");
 
 	/* location bar */
@@ -5929,7 +5918,7 @@ fr_window_construct (FrWindow *window)
 
 	/* current location */
 
-	location_box = gtk_hbox_new (FALSE, 6);
+	location_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
 	/* Translators: after the colon there is a folder name. */
 	window->priv->location_label = gtk_label_new_with_mnemonic (_("_Location:"));
 	gtk_box_pack_start (GTK_BOX (location_box),
@@ -5990,10 +5979,8 @@ fr_window_construct (FrWindow *window)
 	statusbar = GTK_STATUSBAR (window->priv->statusbar);
 
 	/*reduce size of statusbar */
-#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_set_margin_top (GTK_WIDGET (statusbar), 0);
 	gtk_widget_set_margin_bottom (GTK_WIDGET (statusbar), 0);
-#endif
 
 	statusbar_box = gtk_statusbar_get_message_area (statusbar);
 	gtk_box_set_homogeneous (GTK_BOX (statusbar_box), FALSE);
@@ -6006,7 +5993,7 @@ fr_window_construct (FrWindow *window)
 	{
 		GtkWidget *vbox;
 
-		vbox = gtk_vbox_new (FALSE, 0);
+		vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 		gtk_box_pack_start (GTK_BOX (statusbar_box), vbox, FALSE, FALSE, 0);
 		gtk_box_pack_start (GTK_BOX (vbox), window->priv->progress_bar, TRUE, TRUE, 1);
 		gtk_widget_show (vbox);
@@ -7333,7 +7320,7 @@ fr_window_view_last_output (FrWindow   *window,
 
 	/**/
 
-	vbox = gtk_vbox_new (FALSE, 6);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 	gtk_container_set_border_width (GTK_CONTAINER (vbox), 5);
 
 	gtk_container_add (GTK_CONTAINER (scrolled), text_view);
@@ -8235,11 +8222,7 @@ fr_window_open_files_with_application (FrWindow *window,
 	for (scan = file_list; scan; scan = scan->next)
 		uris = g_list_prepend (uris, g_filename_to_uri (scan->data, NULL, NULL));
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 	context = gdk_display_get_app_launch_context (gtk_widget_get_display (GTK_WIDGET (window)));
-#else
-	context = gdk_app_launch_context_new ();
-#endif
 	gdk_app_launch_context_set_screen (context, gtk_widget_get_screen (GTK_WIDGET (window)));
 	gdk_app_launch_context_set_timestamp (context, 0);
 
@@ -8489,11 +8472,7 @@ fr_window_open_extracted_files (OpenFilesData *odata)
 		}
 	}
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 	context = gdk_display_get_app_launch_context (gtk_widget_get_display (GTK_WIDGET (odata->window)));
-#else
-	context = gdk_app_launch_context_new ();
-#endif
 	gdk_app_launch_context_set_screen (context, gtk_widget_get_screen (GTK_WIDGET (odata->window)));
 	gdk_app_launch_context_set_timestamp (context, 0);
 	result = g_app_info_launch_uris (app, files_to_open, G_APP_LAUNCH_CONTEXT (context), &error);

--- a/src/gtk-utils.c
+++ b/src/gtk-utils.c
@@ -27,11 +27,6 @@
 
 #define LOAD_BUFFER_SIZE 65536
 
-#if GTK_CHECK_VERSION (3, 0, 0)
-#define gtk_vbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_VERTICAL, Y)
-#define gtk_hbox_new(X, Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL, Y)
-#endif
-
 static void
 count_selected (GtkTreeModel *model,
 		GtkTreePath  *path,
@@ -113,7 +108,7 @@ _gtk_message_dialog_new (GtkWindow        *parent,
 	gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
 	gtk_label_set_selectable (GTK_LABEL (label), TRUE);
 
-	hbox = gtk_hbox_new (FALSE, 24);
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 24);
 	gtk_container_set_border_width (GTK_CONTAINER (hbox), 5);
 
 	gtk_box_pack_start (GTK_BOX (hbox), image,
@@ -215,19 +210,15 @@ _gtk_request_dialog_run (GtkWindow        *parent,
 	/* Add label and image */
 
 	image = gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_DIALOG);
-#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_set_halign (image, GTK_ALIGN_CENTER);
 	gtk_widget_set_valign (image, GTK_ALIGN_START);
-#else
-	gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.0);
-#endif
 
 	label = gtk_label_new_with_mnemonic (message);
 	gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
 	gtk_label_set_selectable (GTK_LABEL (label), FALSE);
-#if GTK_CHECK_VERSION (3, 0, 0)
-	gtk_widget_set_halign (label, GTK_ALIGN_START);
-	gtk_widget_set_valign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_label_set_yalign (GTK_LABEL (label), 0.0);
 #else
 	gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.0);
 #endif
@@ -239,8 +230,8 @@ _gtk_request_dialog_run (GtkWindow        *parent,
 	gtk_entry_set_text (GTK_ENTRY (entry), default_value);
 	gtk_label_set_mnemonic_widget (GTK_LABEL (label), entry);
 
-	hbox = gtk_hbox_new (FALSE, 12);
-	vbox = gtk_vbox_new (FALSE, 12);
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
 
 	gtk_container_set_border_width (GTK_CONTAINER (dialog), 5);
 	gtk_container_set_border_width (GTK_CONTAINER (hbox), 5);
@@ -315,7 +306,7 @@ _gtk_yesno_dialog_new (GtkWindow        *parent,
 	gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
 	gtk_label_set_selectable (GTK_LABEL (label), TRUE);
 
-	hbox = gtk_hbox_new (FALSE, 24);
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 24);
 	gtk_container_set_border_width (GTK_CONTAINER (hbox), 6);
 
 	gtk_box_pack_start (GTK_BOX (hbox), image,
@@ -395,19 +386,15 @@ _gtk_error_dialog_new (GtkWindow        *parent,
 	/* Add label and image */
 
 	image = gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_DIALOG);
-#if GTK_CHECK_VERSION (3, 0, 0)
 	gtk_widget_set_halign (image, GTK_ALIGN_CENTER);
 	gtk_widget_set_valign (image, GTK_ALIGN_START);
-#else
-	gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.0);
-#endif
 
 	label = gtk_label_new ("");
 	gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
 	gtk_label_set_selectable (GTK_LABEL (label), TRUE);
-#if GTK_CHECK_VERSION (3, 0, 0)
-	gtk_widget_set_halign (label, GTK_ALIGN_START);
-	gtk_widget_set_valign (label, GTK_ALIGN_START);
+#if GTK_CHECK_VERSION (3, 16, 0)
+	gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+	gtk_label_set_yalign (GTK_LABEL (label), 0.0);
 #else
 	gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.0);
 #endif
@@ -478,9 +465,9 @@ _gtk_error_dialog_new (GtkWindow        *parent,
 		gtk_text_view_set_cursor_visible (GTK_TEXT_VIEW (text_view), FALSE);
 	}
 
-	vbox = gtk_vbox_new (FALSE, 6);
+	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
 
-	hbox = gtk_hbox_new (FALSE, 12);
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
 	gtk_box_pack_start (GTK_BOX (hbox), image, FALSE, FALSE, 0);
 	gtk_box_pack_start (GTK_BOX (hbox), label, FALSE, FALSE, 0);
 	gtk_box_pack_start (GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
@@ -682,11 +669,7 @@ get_themed_icon_pixbuf (GThemedIcon  *icon,
 		g_clear_error (&error);
 	}
 
-#if GTK_CHECK_VERSION (3, 0, 0)
 	g_object_unref (icon_info);
-#else
-	gtk_icon_info_free (icon_info);
-#endif
 	g_strfreev (icon_names);
 
 	return pixbuf;


### PR DESCRIPTION
@flexiondotorg @clefebvre @raveit65 @posophe @XRevan86 @willysr @obache @NP-Hardass

Next one... now we move Engrampa to GTK+3 - but with one exception:

Caja extension will be always built with GTK+ version that is used by libcaja-extension. It's autodetected at build time.
It is technically possible because Caja extension doesn't need any code from Engrampa at build time. It only invokes Engrampa binary at runtime.

Other changes are as usual:
- minimum GTK+ version is set to 3.14
- GTK+2 code is dropped
- ```--with-gtk``` build option is dropped as well
- build-dep on GTK+ is changed (that's what you need to do in your distros)

