### PR TITLE
Fix: rar file listing now shows correct date

### DIFF
--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -55,6 +55,43 @@ have_rar (void)
 
 /* -- list -- */
 
+/*
+
+// SAMPLE RAR VERSION 5 LISTING OUTPUT:
+
+RAR 5.40   Copyright (c) 1993-2016 Alexander Roshal   15 Aug 2016
+Trial version             Type RAR -? for help
+
+Archive: test.rar
+Details: RAR 4
+
+ Attributes      Size    Packed Ratio    Date    Time   Checksum  Name
+----------- ---------  -------- ----- ---------- -----  --------  ----
+ -rw-rw-r--      3165      1310  41%  2017-03-07 21:34  888D50B3  loremipsum.txt
+ -rw-rw-r--         0         8   0%  2017-03-07 21:36  00000000  file2.empty
+----------- ---------  -------- ----- ---------- -----  --------  ----
+                 3165      1318  41%                              2
+
+
+
+// SAMPLE RAR VERSION 4 LISTING OUTPUT:
+
+RAR 4.20   Copyright (c) 1993-2012 Alexander Roshal   9 Jun 2012
+Trial version             Type RAR -? for help
+
+Archive test.rar
+
+Pathname/Comment
+                  Size   Packed Ratio  Date   Time     Attr      CRC   Meth Ver
+-------------------------------------------------------------------------------
+ loremipsum.txt
+                  3165     1310  41% 07-03-17 21:34 -rw-rw-r-- 888D50B3 m3b 2.9
+ file2.empty
+                     0        8   0% 07-03-17 21:36 -rw-rw-r-- 00000000 m3b 2.9
+-------------------------------------------------------------------------------
+    2             3165     1318  41%
+
+*/
 
 static time_t
 mktime_from_string (const char *date_s,
@@ -69,11 +106,11 @@ mktime_from_string (const char *date_s,
 
 	fields = g_strsplit (date_s, "-", 3);
 	if (fields[0] != NULL) {
-		tm.tm_mday = atoi (fields[0]);
+		tm.tm_year = atoi (fields[0]) - 1900;
 		if (fields[1] != NULL) {
 			tm.tm_mon = atoi (fields[1]) - 1;
 			if (fields[2] != NULL)
-				tm.tm_year = 100 + atoi (fields[2]);
+				tm.tm_mday = atoi (fields[2]);
 		}
 	}
 	g_strfreev (fields);
@@ -90,39 +127,6 @@ mktime_from_string (const char *date_s,
 
 	return mktime (&tm);
 }
-
-/* Sample rar-5 listing output:
-
-RAR 5.00 beta 8   Copyright (c) 1993-2013 Alexander Roshal   22 Aug 2013
-Trial version             Type RAR -? for help
-
-Archive: test.rar
-Details: RAR 4
-
- Attributes      Size    Packed Ratio   Date   Time   Checksum  Name
------------ ---------  -------- ----- -------- -----  --------  ----
- -rw-r--r--       453       304  67%  05-09-13 09:55  56DA5EF3  loremipsum.txt
------------ ---------  -------- ----- -------- -----  --------  ----
-                  453       304  67%                            1
-
- *
- * Sample rar-4 listing output:
- *
-
-RAR 4.20   Copyright (c) 1993-2012 Alexander Roshal   9 Jun 2012
-Trial version             Type RAR -? for help
-
-Archive test.rar
-
-Pathname/Comment
-                  Size   Packed Ratio  Date   Time     Attr      CRC   Meth Ver
--------------------------------------------------------------------------------
- loremipsum.txt
-                   453      304  67% 05-09-13 09:55 -rw-r--r-- 56DA5EF3 m3b 2.9
--------------------------------------------------------------------------------
-    1              453      304  67%
-
- */
 
 static gboolean
 attribute_field_with_space (char *line)

--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -59,10 +59,10 @@ have_rar (void)
 
 // SAMPLE RAR VERSION 5.3+ LISTING OUTPUT:
 
-RAR 5.40   Copyright (c) 1993-2016 Alexander Roshal   15 Aug 2016
+RAR 5.30   Copyright (c) 1993-2015 Alexander Roshal   18 Nov 2015
 Trial version             Type RAR -? for help
 
-Archive: test.rar
+Archive: /test.rar
 Details: RAR 4
 
  Attributes      Size    Packed Ratio    Date    Time   Checksum  Name
@@ -74,18 +74,29 @@ Details: RAR 4
 
 
 
-// SAMPLE RAR VERSION 5+ < 5.3 LISTING OUTPUT:
+// SAMPLE RAR VERSION 5 TO 5.2 LISTING OUTPUT:
 
-x
+RAR 5.21   Copyright (c) 1993-2015 Alexander Roshal   15 Feb 2015
+Trial version             Type RAR -? for help
+
+Archive: /test.rar
+Details: RAR 4
+
+ Attributes      Size    Packed Ratio   Date   Time   Checksum  Name
+----------- ---------  -------- ----- -------- -----  --------  ----
+ -rw-rw-r--      3165      1310  41%  07-03-17 21:34  888D50B3  loremipsum.txt
+ -rw-rw-r--         0         8   0%  07-03-17 21:36  00000000  file2.empty 
+----------- ---------  -------- ----- -------- -----  --------  ----
+                 3165      1318  41%                            2
 
 
 
-// SAMPLE RAR VERSION 4 LISTING OUTPUT:
+// SAMPLE RAR VERSION 4 AND UNDER LISTING OUTPUT:
 
 RAR 4.20   Copyright (c) 1993-2012 Alexander Roshal   9 Jun 2012
 Trial version             Type RAR -? for help
 
-Archive test.rar
+Archive /test.rar
 
 Pathname/Comment
                   Size   Packed Ratio  Date   Time     Attr      CRC   Meth Ver

--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -57,7 +57,7 @@ have_rar (void)
 
 /*
 
-// SAMPLE RAR VERSION 5 LISTING OUTPUT:
+// SAMPLE RAR VERSION 5.3+ LISTING OUTPUT:
 
 RAR 5.40   Copyright (c) 1993-2016 Alexander Roshal   15 Aug 2016
 Trial version             Type RAR -? for help
@@ -71,6 +71,12 @@ Details: RAR 4
  -rw-rw-r--         0         8   0%  2017-03-07 21:36  00000000  file2.empty
 ----------- ---------  -------- ----- ---------- -----  --------  ----
                  3165      1318  41%                              2
+
+
+
+// SAMPLE RAR VERSION 5+ < 5.3 LISTING OUTPUT:
+
+x
 
 
 

--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -57,7 +57,7 @@ have_rar (void)
 
 /*
 
-// SAMPLE RAR VERSION 5.3+ LISTING OUTPUT:
+// SAMPLE RAR VERSION 5.30 AND NEWER LISTING OUTPUT:
 
 RAR 5.30   Copyright (c) 1993-2015 Alexander Roshal   18 Nov 2015
 Trial version             Type RAR -? for help
@@ -74,7 +74,7 @@ Details: RAR 4
 
 
 
-// SAMPLE RAR VERSION 5 TO 5.2 LISTING OUTPUT:
+// SAMPLE RAR VERSION 5.00 TO 5.21 LISTING OUTPUT:
 
 RAR 5.21   Copyright (c) 1993-2015 Alexander Roshal   15 Feb 2015
 Trial version             Type RAR -? for help
@@ -91,7 +91,7 @@ Details: RAR 4
 
 
 
-// SAMPLE RAR VERSION 4 AND UNDER LISTING OUTPUT:
+// SAMPLE RAR VERSION 4.20 AND OLDER LISTING OUTPUT:
 
 RAR 4.20   Copyright (c) 1993-2012 Alexander Roshal   9 Jun 2012
 Trial version             Type RAR -? for help


### PR DESCRIPTION
rar before version 5 used DD-MM-YY, but more recent rar versions use YYYY-MM-DD, most people using rar would and should be using recent versions

this fix reorders the string split so year is first and day is last in order to show the correct date when using rar version 5 onward

the newer date format matches the one used by tar, so this fix also adjusts the year line to support four characters instead of two

updated example listing output for both rar versions is included and moved before the time function instead of after