### PR TITLE
extract dialog: always ask whether to overwrite

### DIFF
--- a/data/org.mate.engrampa.gschema.xml.in
+++ b/data/org.mate.engrampa.gschema.xml.in
@@ -133,10 +133,6 @@
     <child name="batch-add" schema="org.mate.engrampa.dialogs.batch-add"/>
   </schema>
   <schema gettext-domain="@GETTEXT_PACKAGE@" id="org.mate.engrampa.dialogs.extract" path="/org/mate/engrampa/dialogs/extract/">
-    <key name="overwrite" type="b">
-      <default>true</default>
-      <summary>Overwrite existing files</summary>
-    </key>
     <key name="skip-newer" type="b">
       <default>false</default>
       <summary>Do not overwrite newer files</summary>

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -59,7 +59,6 @@
 #define PREF_GENERAL_COMPRESSION_LEVEL	"compression-level"
 #define PREF_GENERAL_ENCRYPT_HEADER	"encrypt-header"
 
-#define PREF_EXTRACT_OVERWRITE		"overwrite"
 #define PREF_EXTRACT_SKIP_NEWER		"skip-newer"
 #define PREF_EXTRACT_RECREATE_FOLDERS	"recreate-folders"
 


### PR DESCRIPTION
Removed the overwrite option in the extract dialog

based in file-roller commit:

https://git.gnome.org/browse/file-roller/commit/?id=fe71357aa128d029b6ca4a9493b8a408c8aaf017

Fixes #161