### PR TITLE
add some style class

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -5420,6 +5420,7 @@ fr_window_construct (FrWindow *window)
 {
 	GtkWidget        *menubar;
 	GtkWidget        *toolbar;
+	GtkStyleContext  *context;
 	GtkWidget        *list_scrolled_window;
 	GtkWidget        *location_box;
 	GtkStatusbar     *statusbar;
@@ -5699,6 +5700,8 @@ fr_window_construct (FrWindow *window)
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (list_scrolled_window),
 					GTK_POLICY_AUTOMATIC,
 					GTK_POLICY_AUTOMATIC);
+	context = gtk_widget_get_style_context (list_scrolled_window);
+	gtk_style_context_add_class (context, "frame");
 	gtk_container_add (GTK_CONTAINER (list_scrolled_window), window->priv->list_view);
 
 	/* filter bar */
@@ -5775,6 +5778,8 @@ fr_window_construct (FrWindow *window)
 	gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (tree_scrolled_window),
 					GTK_POLICY_AUTOMATIC,
 					GTK_POLICY_AUTOMATIC);
+	context = gtk_widget_get_style_context (tree_scrolled_window);
+	gtk_style_context_add_class (context, "frame");
 	gtk_container_add (GTK_CONTAINER (tree_scrolled_window), window->priv->tree_view);
 
 	/* side pane */

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -795,12 +795,17 @@ fr_window_unrealized (GtkWidget *window,
 static void
 fr_window_init (FrWindow *window)
 {
+	GtkStyleContext *context;
+
 	window->priv = g_new0 (FrWindowPrivateData, 1);
 	window->priv->update_dropped_files = FALSE;
 	window->priv->filter_mode = FALSE;
 	window->priv->batch_title = NULL;
 	window->priv->use_progress_dialog = TRUE;
 	window->priv->batch_title = NULL;
+
+	context = gtk_widget_get_style_context (GTK_WIDGET (window));
+	gtk_style_context_add_class (context, "engrampa-window");
 
 	g_signal_connect (window,
 			  "realize",


### PR DESCRIPTION
This adds 'engrampa-window' at top and the 'frame' style class to the scrolledwindows.
scrolledwindow.frame is used to set a border in most themes.
Adding a specific class at top of the code of an application is always a good idea.
At the moment i need this, as i have to set a border on 'frame > border' for firefox in themes to have a border for the locationbar.
See https://github.com/flexiondotorg/ubuntu-mate-themes/issues/35
In result i can remove the border here with
```
.engrampa-window > grid > paned > box > frame > border {
    border-style: none;
}
```