### PR TITLE
Fix: Wrong behavior of Skip button in Replace file dialog

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -3525,6 +3525,24 @@ fr_window_get_file_list_pattern (FrWindow    *window,
 }
 
 
+static GList *
+fr_window_get_file_list (FrWindow *window)
+{
+	GList *list;
+	int    i;
+
+	g_return_val_if_fail (window != NULL, NULL);
+
+	list = NULL;
+	for (i = 0; i < window->archive->command->files->len; i++) {
+		FileData *fd = g_ptr_array_index (window->archive->command->files, i);
+		list = g_list_prepend (list, g_strdup (fd->original_path));
+	}
+
+	return g_list_reverse (list);
+}
+
+
 int
 fr_window_get_n_selected_files (FrWindow *window)
 {
@@ -6656,6 +6674,7 @@ typedef struct {
 	FrWindow    *window;
 	ExtractData *edata;
 	GList       *current_file;
+	gboolean     extract_all;
 } OverwriteData;
 
 
@@ -6710,6 +6729,7 @@ overwrite_dialog_response_cb (GtkDialog *dialog,
 			odata->edata->file_list = g_list_remove_link (odata->edata->file_list, odata->current_file);
 			path_list_free (odata->current_file);
 			odata->current_file = next;
+			odata->extract_all = FALSE;
 		}
 		break;
 
@@ -6737,8 +6757,6 @@ overwrite_dialog_response_cb (GtkDialog *dialog,
 static void
 _fr_window_ask_overwrite_dialog (OverwriteData *odata)
 {
-	gboolean do_not_extract = FALSE;
-
 	while ((odata->edata->overwrite == FR_OVERWRITE_ASK) && (odata->current_file != NULL)) {
 		const char *base_name;
 		char       *e_base_name;
@@ -6809,14 +6827,32 @@ _fr_window_ask_overwrite_dialog (OverwriteData *odata)
 		g_object_unref (file);
 	}
 
-	if (do_not_extract) {
-		fr_window_stop_batch (odata->window);
-		g_free (odata);
-		return;
+	if (odata->edata->file_list != NULL) {
+		/* speed optimization: passing NULL when extracting all the
+		 * files is faster if the command supports the
+		 * propCanExtractAll property. */
+		if (odata->extract_all) {
+			path_list_free (odata->edata->file_list);
+			odata->edata->file_list = NULL;
+		}
+		odata->edata->overwrite = FR_OVERWRITE_YES;
+		_fr_window_archive_extract_from_edata (odata->window, odata->edata);
 	}
+	else {
+		GtkWidget *d;
 
-	odata->edata->overwrite = FR_OVERWRITE_YES;
-	_fr_window_archive_extract_from_edata (odata->window, odata->edata);
+		d = _gtk_message_dialog_new (GTK_WINDOW (odata->window),
+					     0,
+					     GTK_STOCK_DIALOG_WARNING,
+					     _("Extraction not performed"),
+					     NULL,
+					     GTK_STOCK_OK, GTK_RESPONSE_OK,
+					     NULL);
+		gtk_dialog_set_default_response (GTK_DIALOG (d), GTK_RESPONSE_OK);
+		fr_window_show_error_dialog (odata->window, d, GTK_WINDOW (odata->window), _("Extraction not performed"));
+
+		fr_window_stop_batch (odata->window);
+	}
 	g_free (odata);
 }
 
@@ -6933,6 +6969,9 @@ fr_window_archive_extract (FrWindow    *window,
 		odata = g_new0 (OverwriteData, 1);
 		odata->window = window;
 		odata->edata = edata;
+		odata->extract_all = (edata->file_list == NULL) || (g_list_length (edata->file_list) == window->archive->command->files->len);
+		if (edata->file_list == NULL)
+			edata->file_list = fr_window_get_file_list (window);
 		odata->current_file = odata->edata->file_list;
 		_fr_window_ask_overwrite_dialog (odata);
 	}


### PR DESCRIPTION
based in file-roller commit:
https://git.gnome.org/browse/file-roller/commit/?id=fe71357aa128d029b6ca4a9493b8a408c8aaf017

Fixes #161 

I take the needed in that file-roller commit, and I keep the overwrite option in the extract dialog