### PR TITLE
Restore Polish translation credits from GNOME

### DIFF
--- a/po/gnome-copyrights.txt
+++ b/po/gnome-copyrights.txt
@@ -852,12 +852,17 @@
 
 
 ========== pl.po ==========
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
-# Aviary.pl
-# Jeśli masz jakiekolwiek uwagi odnoszące się do tłumaczenia lub chcesz
-# pomóc w jego rozwijaniu i pielęgnowaniu, napisz do nas:
-# matepl@aviary.pl
-# -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+# Polish translation for file-roller.
+# Copyright © 2002-2010 the file-roller authors.
+# This file is distributed under the same license as the file-roller package.
+# Sławomir Mikuła <zorba@silesianet.pl>, 2002.
+# Zbigniew Chyla <chyla@alice.ci.pwr.wroc.pl>, 2003.
+# Artur Flinta <aflinta@at.kernel.pl>, 2003-2006.
+# Wadim Dziedzic <wdziedzic@aviary.pl>, 2007-2008.
+# Tomasz Dominikowski <dominikowski@gmail.com>, 2007-2009.
+# Piotr Drąg <piotrdrag@gmail.com>, 2009-2010.
+# Aviary.pl <gnomepl@aviary.pl>, 2007-2010.
+#
 
 
 
@@ -1108,7 +1113,7 @@
 # 
 # Görkem Çetin <gorkem@gelecek.com.tr>, 2004.
 # Fatih Ergüven <fatih@erguven.org>, 2009.
-# Baris Cicek <baris@teamforce.name.tr>, 2004, 2008, 2009., 2010.
+# Baris Cicek <baris@teamforce.name.tr>, 2004, 2008, 2009, 2010.
 #
 
 


### PR DESCRIPTION
This commit restores proper credits and copyrights for the Polish translation that were somehow lost during forking, using historical information from git.gnome.org.