### PR TITLE
7z: Fix: delete/rename files/folders with the list encrypted

### DIFF
--- a/src/fr-command-7z.c
+++ b/src/fr-command-7z.c
@@ -422,6 +422,8 @@ fr_command_7z_delete (FrCommand  *comm,
 			if (g_str_has_prefix (scan->data, "@"))
 				fr_process_add_arg_concat (comm->process, "-i!", scan->data, NULL);
 
+	add_password_arg (comm, FR_COMMAND (comm)->password, FALSE);
+
 	fr_process_add_arg (comm->process, "--");
 	fr_process_add_arg (comm->process, comm->filename);
 


### PR DESCRIPTION
based in file-roller commit:
https://git.gnome.org/browse/file-roller/commit/?id=0bb26ee4223cdcbca9aa0816c81069b74f15c2f7

Fixes partially https://github.com/mate-desktop/engrampa/issues/185