### PR TITLE
UI: on the properties dialog, focus the Close button by default

### DIFF
--- a/src/ui/properties.ui
+++ b/src/ui/properties.ui
@@ -23,9 +23,7 @@
                 <property name="label">gtk-help</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
                 <property name="can_default">True</property>
-                <property name="has_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
               </object>
@@ -41,7 +39,9 @@
                 <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
                 <property name="can_default">True</property>
+                <property name="has_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="use_stock">True</property>
               </object>


### PR DESCRIPTION
the Close button, not the Help button, should be the one set to default so that you can press Enter or Space without unintentionally opening the help manual