### PR TITLE
%'d -> %d

### DIFF
--- a/engrampa.pot
+++ b/engrampa.pot
@@ -977,7 +977,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/af.po
+++ b/po/af.po
@@ -999,7 +999,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/am.po
+++ b/po/am.po
@@ -1000,7 +1000,7 @@ msgstr "ፋይሎች _ማሳያ እና ማጥፊያ"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -1034,7 +1034,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/as.po
+++ b/po/as.po
@@ -995,7 +995,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ast.po
+++ b/po/ast.po
@@ -995,7 +995,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/az.po
+++ b/po/az.po
@@ -985,7 +985,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/be.po
+++ b/po/be.po
@@ -1030,7 +1030,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -1056,7 +1056,7 @@ msgstr "Показване на _файловете и изход"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/bn.po
+++ b/po/bn.po
@@ -1004,7 +1004,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -1004,7 +1004,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/br.po
+++ b/po/br.po
@@ -1049,7 +1049,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/bs.po
+++ b/po/bs.po
@@ -984,7 +984,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -1030,9 +1030,9 @@ msgstr "Mostra els _fitxers i surt"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d fitxer restant"
-msgstr[1] "%'d fitxers restants"
+msgstr[1] "%d fitxers restants"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -1032,9 +1032,9 @@ msgstr "Mostra els _fitxers i ix"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d fitxer restant"
-msgstr[1] "%'d fitxers restants"
+msgstr[1] "%d fitxers restants"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/cmn.po
+++ b/po/cmn.po
@@ -991,7 +991,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/crh.po
+++ b/po/crh.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -1059,11 +1059,11 @@ msgstr "Zobrazit _soubory a ukončit"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "Zbývá %d soubor"
-msgstr[1] "Zbývají %'d soubory"
-msgstr[2] "Zbývá %'d souborů"
-msgstr[3] "Zbývá %'d souborů"
+msgstr[1] "Zbývají %d soubory"
+msgstr[2] "Zbývá %d souborů"
+msgstr[3] "Zbývá %d souborů"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/cy.po
+++ b/po/cy.po
@@ -992,7 +992,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/da.po
+++ b/po/da.po
@@ -1049,9 +1049,9 @@ msgstr "Vis _filerne og afslut"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d fil tilbage"
-msgstr[1] "%'d filer tilbage"
+msgstr[1] "%d filer tilbage"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/de.po
+++ b/po/de.po
@@ -1064,9 +1064,9 @@ msgstr "_Dateien anzeigen und Beenden"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "noch %d Datei"
-msgstr[1] "noch %'d Dateien"
+msgstr[1] "noch %d Dateien"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/dz.po
+++ b/po/dz.po
@@ -1002,7 +1002,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/el.po
+++ b/po/el.po
@@ -1066,7 +1066,7 @@ msgstr "Εμφάνιση των _Αρχείων και Τερματισμός"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/en_AU.po
+++ b/po/en_AU.po
@@ -1039,7 +1039,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/en_CA.po
+++ b/po/en_CA.po
@@ -999,7 +999,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1043,7 +1043,7 @@ msgstr "Show the _Files and Quit"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -1008,7 +1008,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -1048,7 +1048,7 @@ msgstr "Mostrar los _archivos y salir"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_CL.po
+++ b/po/es_CL.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_CO.po
+++ b/po/es_CO.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_CR.po
+++ b/po/es_CR.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_DO.po
+++ b/po/es_DO.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_EC.po
+++ b/po/es_EC.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_MX.po
+++ b/po/es_MX.po
@@ -985,7 +985,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_NI.po
+++ b/po/es_NI.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_PA.po
+++ b/po/es_PA.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_PE.po
+++ b/po/es_PE.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_PR.po
+++ b/po/es_PR.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_SV.po
+++ b/po/es_SV.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_UY.po
+++ b/po/es_UY.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/es_VE.po
+++ b/po/es_VE.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/et.po
+++ b/po/et.po
@@ -1014,9 +1014,9 @@ msgstr "Näita _faile ja lõpeta"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "Veel %d fail"
-msgstr[1] "Veel %'d faili"
+msgstr[1] "Veel %d faili"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/eu.po
+++ b/po/eu.po
@@ -1001,7 +1001,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -984,7 +984,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -1032,7 +1032,7 @@ msgstr "Näytä Tiedostot ja Lopeta"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1067,9 +1067,9 @@ msgstr "Afficher les _fichiers et quitter"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d fichier restant"
-msgstr[1] "%'d fichiers restants"
+msgstr[1] "%d fichiers restants"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/fr_CA.po
+++ b/po/fr_CA.po
@@ -977,7 +977,7 @@ msgstr ""
 #: ../src/fr-window.c:2721
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/frp.po
+++ b/po/frp.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/fur.po
+++ b/po/fur.po
@@ -997,7 +997,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/fy.po
+++ b/po/fy.po
@@ -993,7 +993,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ga.po
+++ b/po/ga.po
@@ -1000,7 +1000,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/gl.po
+++ b/po/gl.po
@@ -1002,7 +1002,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/gu.po
+++ b/po/gu.po
@@ -995,7 +995,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ha.po
+++ b/po/ha.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -1006,7 +1006,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -1002,7 +1002,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -1018,7 +1018,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -1053,9 +1053,9 @@ msgstr "_Fájl megjelenítése és kilépés"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d fájl van hátra"
-msgstr[1] "%'d fájl van hátra"
+msgstr[1] "%d fájl van hátra"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/hy.po
+++ b/po/hy.po
@@ -1040,7 +1040,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ia.po
+++ b/po/ia.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -1043,7 +1043,7 @@ msgstr "Tampilkan _Berkas dan Keluar"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/ig.po
+++ b/po/ig.po
@@ -975,7 +975,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/is.po
+++ b/po/is.po
@@ -981,7 +981,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -1043,7 +1043,7 @@ msgstr "Mostra i _file ed esci"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -1028,7 +1028,7 @@ msgstr "ファイルを表示して終了する(_F)"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/jv.po
+++ b/po/jv.po
@@ -977,7 +977,7 @@ msgstr ""
 #: ../src/fr-window.c:2721
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -990,7 +990,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/kk.po
+++ b/po/kk.po
@@ -998,7 +998,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/kn.po
+++ b/po/kn.po
@@ -997,7 +997,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -1022,7 +1022,7 @@ msgstr "파일을 보이고 닫기(_F)"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/ks.po
+++ b/po/ks.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ku.po
+++ b/po/ku.po
@@ -991,7 +991,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ku_IQ.po
+++ b/po/ku_IQ.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ky.po
+++ b/po/ky.po
@@ -999,7 +999,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/li.po
+++ b/po/li.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -1065,11 +1065,11 @@ msgstr "Rodyti _failus ir išeiti"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "Liko %d failas"
-msgstr[1] "Liko %'d failai"
-msgstr[2] "Liko %'d failų"
-msgstr[3] "Liko %'d failų"
+msgstr[1] "Liko %d failai"
+msgstr[2] "Liko %d failų"
+msgstr[3] "Liko %d failų"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/lv.po
+++ b/po/lv.po
@@ -1005,7 +1005,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/mai.po
+++ b/po/mai.po
@@ -984,7 +984,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/mg.po
+++ b/po/mg.po
@@ -987,7 +987,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/mi.po
+++ b/po/mi.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/mk.po
+++ b/po/mk.po
@@ -998,7 +998,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ml.po
+++ b/po/ml.po
@@ -1000,7 +1000,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/mn.po
+++ b/po/mn.po
@@ -983,7 +983,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -1001,7 +1001,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ms.po
+++ b/po/ms.po
@@ -1043,8 +1043,8 @@ msgstr "Tunjuk _Fail kemudian Keluar"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
-msgstr[0] "%'d fail berbaki"
+msgid_plural "%d files remaining"
+msgstr[0] "%d fail berbaki"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/nb.po
+++ b/po/nb.po
@@ -1049,7 +1049,7 @@ msgstr "Vis _filene og avslutt"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/nds.po
+++ b/po/nds.po
@@ -981,7 +981,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ne.po
+++ b/po/ne.po
@@ -998,7 +998,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -1059,9 +1059,9 @@ msgstr "Toon de _bestanden en sluit af"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d bestand resterend"
-msgstr[1] "%'d bestanden resterend"
+msgstr[1] "%d bestanden resterend"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/nn.po
+++ b/po/nn.po
@@ -1000,7 +1000,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/nso.po
+++ b/po/nso.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/oc.po
+++ b/po/oc.po
@@ -1004,7 +1004,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/or.po
+++ b/po/or.po
@@ -1001,7 +1001,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -1003,7 +1003,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1068,11 +1068,11 @@ msgstr "Wyświetl _pliki i zakończ"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "Pozostał %d plik"
-msgstr[1] "Pozostały %'d pliki"
-msgstr[2] "Pozostało %'d plików"
-msgstr[3] "Pozostało %'d plików"
+msgstr[1] "Pozostały %d pliki"
+msgstr[2] "Pozostało %d plików"
+msgstr[3] "Pozostało %d plików"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/pms.po
+++ b/po/pms.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ps.po
+++ b/po/ps.po
@@ -994,7 +994,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -1043,7 +1043,7 @@ msgstr "Mostrar os _Ficheiros e Sair"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1071,9 +1071,9 @@ msgstr "Mostra os _Arquivos e sair"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%darquivos restantes"
-msgstr[1] "%'d arquivos restantes"
+msgstr[1] "%d arquivos restantes"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1046,7 +1046,7 @@ msgstr "Arată _Fișierele și Ieși"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1085,11 +1085,11 @@ msgstr "Показать _файлы и выйти"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d файл остался"
-msgstr[1] "%'d файлов осталось"
-msgstr[2] "%'d файлов осталось"
-msgstr[3] "%'d файлов осталось"
+msgstr[1] "%d файлов осталось"
+msgstr[2] "%d файлов осталось"
+msgstr[3] "%d файлов осталось"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/rw.po
+++ b/po/rw.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/sc.po
+++ b/po/sc.po
@@ -981,7 +981,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -981,7 +981,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -1052,7 +1052,7 @@ msgstr "Zobraziť _súbory a skončiť"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -1020,7 +1020,7 @@ msgstr "Pokaži _datoteke in končaj"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/sq.po
+++ b/po/sq.po
@@ -999,7 +999,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -1046,7 +1046,7 @@ msgstr "Прикажи _датотеке и изађи"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1007,7 +1007,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1039,7 +1039,7 @@ msgstr "Visa _Filer och Avsluta"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -1008,7 +1008,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -994,7 +994,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -999,7 +999,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/tk.po
+++ b/po/tk.po
@@ -981,7 +981,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1057,9 +1057,9 @@ msgstr "_Dosyaları Göster ve Çık"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "%d dosya kaldı"
-msgstr[1] "%'d dosya kaldı"
+msgstr[1] "%d dosya kaldı"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/tt.po
+++ b/po/tt.po
@@ -975,7 +975,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/ug.po
+++ b/po/ug.po
@@ -1005,7 +1005,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/uk.po
+++ b/po/uk.po
@@ -1045,7 +1045,7 @@ msgstr "Показати _Файли і Вийти"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""

--- a/po/ur.po
+++ b/po/ur.po
@@ -1005,7 +1005,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/ur_PK.po
+++ b/po/ur_PK.po
@@ -998,7 +998,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/uz.po
+++ b/po/uz.po
@@ -985,7 +985,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/vi.po
+++ b/po/vi.po
@@ -1000,7 +1000,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/wa.po
+++ b/po/wa.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/xh.po
+++ b/po/xh.po
@@ -985,7 +985,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/yi.po
+++ b/po/yi.po
@@ -978,7 +978,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/po/yo.po
+++ b/po/yo.po
@@ -975,7 +975,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1014,7 +1014,7 @@ msgstr "显示文件并退出(_F)"
 #, c-format
 msgid "%d file remaining"
 msgid_plural "%d files remaining"
-msgstr[0] "剩余 %‘d 个文件"
+msgstr[0] "剩余 %d 个文件"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1013,7 +1013,7 @@ msgstr "显示文件并退出(_F)"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] "剩余 %‘d 个文件"
 
 #: ../src/fr-window.c:2759

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -991,7 +991,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 
 #: ../src/fr-window.c:2759

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1012,8 +1012,8 @@ msgstr "顯示檔案並結束(_F)"
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
-msgstr[0] "剩餘 %'d 個檔案"
+msgid_plural "%d files remaining"
+msgstr[0] "剩餘 %d 個檔案"
 
 #: ../src/fr-window.c:2759
 msgid "Extraction completed successfully"

--- a/po/zu.po
+++ b/po/zu.po
@@ -980,7 +980,7 @@ msgstr ""
 #: ../src/fr-window.c:2708
 #, c-format
 msgid "%d file remaining"
-msgid_plural "%'d files remaining"
+msgid_plural "%d files remaining"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -2706,7 +2706,7 @@ fr_window_progress_cb (FrArchive *archive,
 			case FR_ACTION_EXTRACTING_FILES:
 			case FR_ACTION_DELETING_FILES:
 				message = g_strdup_printf (ngettext ("%d file remaining",
-								     "%'d files remaining",
+								     "%d files remaining",
 								     remaining_files), remaining_files);
 				break;
 			default:


### PR DESCRIPTION
In [engrampa.pot](https://github.com/mate-desktop/engrampa/blob/master/engrampa.pot#L980), The "msgid_plural" was defined as "%'d files remaining". But we all know it should be "%d".

![](https://camo.githubusercontent.com/4048e181199d014391c53108753120a176cff8c0/68747470733a2f2f7773312e73696e61696d672e636e2f6c617267652f3030363446316e4e6c7931667579676230336971306a333065613036716161612e6a7067)
It's Chinese, forgive me.

More than that, all translation refer the engrampa.pot. So all of them are wrong.