### PR TITLE
fr-window: fix typo

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -2706,7 +2706,7 @@ fr_window_progress_cb (FrArchive *archive,
 			case FR_ACTION_EXTRACTING_FILES:
 			case FR_ACTION_DELETING_FILES:
 				message = g_strdup_printf (ngettext ("%d file remaining",
-								     "%'d files remaining",
+								     "%d files remaining",
 								     remaining_files), remaining_files);
 				break;
 			default:


### PR DESCRIPTION
Real fix for https://github.com/mate-desktop/engrampa/pull/216
Test with generating engrampa.pot in main dir.
`./autogen.sh && ./makepot`
After merging engrampa.pot can be updated and commited in github.
The resource file at transifex will be automatic updated from git.
And translators can update translations.