### PR TITLE
Fixed xz package name

### DIFF
--- a/data/packages.match
+++ b/data/packages.match
@@ -27,6 +27,7 @@ unrar=
 unstaff=
 unzip=
 xz=
+xz-utils=
 zip=
 zoo=
 

--- a/src/fr-command-cfile.c
+++ b/src/fr-command-cfile.c
@@ -569,7 +569,7 @@ fr_command_cfile_get_packages (FrCommand  *comm,
 	else if (is_mime_type (mime_type, "application/x-lzma"))
 		return PACKAGES ("lzma");
 	else if (is_mime_type (mime_type, "application/x-xz"))
-		return PACKAGES ("xz");
+		return PACKAGES ("xz,xz-utils");
 	else if (is_mime_type (mime_type, "application/x-lzop"))
 		return PACKAGES ("lzop");
 	else if (is_mime_type (mime_type, "application/x-rzip"))

--- a/src/fr-command-tar.c
+++ b/src/fr-command-tar.c
@@ -1118,7 +1118,7 @@ fr_command_tar_get_packages (FrCommand  *comm,
 	else if (is_mime_type (mime_type, "application/x-lzma-compressed-tar"))
 		return PACKAGES ("tar,lzma");
 	else if (is_mime_type (mime_type, "application/x-xz-compressed-tar"))
-		return PACKAGES ("tar,xz");
+		return PACKAGES ("tar,xz,xz-utils");
 	else if (is_mime_type (mime_type, "application/x-lzop-compressed-tar"))
 		return PACKAGES ("tar,lzop");
 	else if (is_mime_type (mime_type, "application/x-7z-compressed-tar"))


### PR DESCRIPTION
The correct name for `xz` package is `xz-utils`:
https://packages.debian.org/search?keywords=xz-utils&searchon=names&suite=stable&section=all
