### PR TITLE
fr-window: show the pause button only if the dialog is working

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -2741,6 +2741,7 @@ open_progress_dialog (FrWindow *window,
 
 	create_the_progress_dialog (window);
 	gtk_widget_show (window->priv->pd_cancel_button);
+	gtk_widget_show (window->priv->pd_state_button);
 	gtk_widget_hide (window->priv->pd_open_archive_button);
 	gtk_widget_hide (window->priv->pd_open_destination_button);
 	gtk_widget_hide (window->priv->pd_open_destination_and_quit_button);
@@ -2822,6 +2823,7 @@ open_progress_dialog_with_open_destination (FrWindow *window)
 
 	create_the_progress_dialog (window);
 	gtk_widget_hide (window->priv->pd_cancel_button);
+	gtk_widget_hide (window->priv->pd_state_button);
 	gtk_widget_hide (window->priv->pd_open_archive_button);
 	gtk_widget_show (window->priv->pd_open_destination_button);
 	gtk_widget_show (window->priv->pd_open_destination_and_quit_button);
@@ -2847,6 +2849,7 @@ open_progress_dialog_with_open_archive (FrWindow *window)
 
 	create_the_progress_dialog (window);
 	gtk_widget_hide (window->priv->pd_cancel_button);
+	gtk_widget_hide (window->priv->pd_state_button);
 	gtk_widget_hide (window->priv->pd_open_destination_button);
 	gtk_widget_hide (window->priv->pd_open_destination_and_quit_button);
 	gtk_widget_show (window->priv->pd_open_archive_button);


### PR DESCRIPTION
Fixes this issue:

![2018-12-10_22-53](https://user-images.githubusercontent.com/7734191/49763971-74552600-fcce-11e8-8664-6be869e20f3d.png)

The pause button must be hidden here

How to show this dialog? with the button "extract" in the toolbar, or with "archive" -> "extract" in menus.