### PR TITLE
Upgrade the manual to docbook 5.0

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1,36 +1,24 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE article PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN" 
-"http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
-  <!ENTITY legal SYSTEM "legal.xml">
-  <!ENTITY appversion "1.10">
-  <!ENTITY manrevision "1.10.0">
-  <!ENTITY date "July 2015">
-  <!ENTITY appname "Archive Manager">
-  <!ENTITY app "<application>Archive Manager</application>">
-  <!-- Information about the entities
-       The legal.xml file contains legal information, there is no need to edit the file. 
-       Use the appversion entity to specify the version of the application.
-       Use the manrevision entity to specify the revision number of this manual.
-       Use the date entity to specify the release date of this manual.
-       Use the app entity to specify the name of the application. -->
-]>
-<!-- 
+<?xml version="1.0" encoding="utf-8"?>
+<!--
       (Do not remove this comment block.)
   Maintained by the MATE Documentation Project
   http://wiki.mate-desktop.org/dev-doc:doc-team-guide
   Template version: 2.0 beta
   Template last modified Jan 30, 2002
 -->
-<!-- =============Document Header ============================= -->
-<article id="index" lang="en">
+<article xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         version="5.0" xml:id="index" xml:lang="en">
 <!-- please do not change the id; for translations, change lang to -->
 <!-- appropriate code -->
-  <articleinfo> 
-    <title>&app; Manual</title>
-     <abstract role="description">
+  <info><title>Archive Manager Manual</title> 
+
+     <abstract>
        <para>Archive Manager, also known as Engrampa, allows you to create, view, modify, or unpack an archive.</para>
      </abstract>
-    <copyright lang="en">
+
+    <copyright xml:lang="en">
       <year>2015</year>
       <holder>MATE Documentation Project</holder>
     </copyright>
@@ -57,15 +45,6 @@
       <holder>Alexander Kirillov</holder> 
     </copyright> 
 
-
-<!-- translators: uncomment this:
-
-  <copyright>
-   <year>2002</year>
-   <holder>ME-THE-TRANSLATOR (Latin translation)</holder>
-  </copyright>
-
-   -->
 <!-- An address can be added to the publisher information.  If a role is 
      not specified, the publisher/author is the same for all versions of the 
      document.  -->
@@ -76,63 +55,72 @@
       <publishername>GNOME Documentation Project</publishername>
     </publisher>
 
-   &legal; <!-- This file contains link to license for the
+  <xi:include href="legal.xml"/>
+  <!-- This file contains link to license for the
    documentation (GNU FDL), and other legal stuff such as "NO
    WARRANTY" statement. Please do not change any of this. -->
 
-    <authorgroup>
-      <author role="maintainer" lang="en">
-	<surname>MATE Documentation Team</surname>
-	<affiliation>
-	  <orgname>Mate desktop</orgname>
-	</affiliation>
+  <authorgroup>
+      <author>
+          <orgname>MATE Documentation Project</orgname>
+          <affiliation>
+              <orgname>MATE Desktop</orgname>
+          </affiliation>
       </author>
-       <author>
-         <firstname>Sun </firstname>
-         <surname>GNOME Documentation Team</surname>
-         <affiliation> 
-            <orgname>Sun Microsystems</orgname>
-        </affiliation>
+      <author>
+          <personname>
+              <firstname>Sun </firstname>
+              <surname>GNOME Documentation Team</surname>
+          </personname>
+          <affiliation> 
+              <orgname>Sun Microsystems</orgname>
+          </affiliation>
       </author>
-      <author> 
-	<firstname>Paolo</firstname> 
-	<surname>Bacchilega</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	</affiliation> 
-      </author> 
-      <author> 
-	<firstname>Alexander</firstname> 
-	<surname>Kirillov</surname> 
-	<affiliation> 
-	  <orgname>GNOME Documentation Project</orgname>
-	  <address> <email>kirillov@math.sunysb.edu</email> </address> 
-	</affiliation> 
+      <author>
+          <personname>
+              <firstname>Paolo</firstname>
+              <surname>Bacchilega</surname>
+          </personname>
+          <affiliation> 
+              <orgname>GNOME Documentation Project</orgname>
+          </affiliation>
       </author> 
       <author>
-        <firstname>Paul</firstname>
-        <surname>Cutler</surname>
-        <affiliation>
-          <orgname>GNOME Documentation Project</orgname>
-          <address><email>pcutler@foresightlinux.org</email></address>
-        </affiliation>
+          <personname>
+              <firstname>Alexander</firstname>
+              <surname>Kirillov</surname>
+          </personname>
+          <affiliation> 
+              <orgname>GNOME Documentation Project</orgname>
+          </affiliation>
+          <email>kirillov@math.sunysb.edu</email> 
+      </author> 
+      <author>
+          <personname>
+              <firstname>Paul</firstname>
+              <surname>Cutler</surname>
+          </personname>
+          <affiliation>
+              <orgname>GNOME Documentation Project</orgname>
+          </affiliation>
+          <email>pcutler@foresightlinux.org</email> 
       </author>	  
-    </authorgroup>
+  </authorgroup>
 	
 	<releaseinfo revision="1.10" role="review">
 	</releaseinfo>
 
          <revhistory>
-                <revision lang="en">
-                  <revnumber>Archive Manager Manual V1.10.0</revnumber>
+                <revision xml:lang="en">
+                  <revnumber>1.10.0</revnumber>
                   <date>July 2015</date>
                   <revdescription>
-                         <para role="author" lang="en">Wolfgang Ulbrich</para>
-                         <para role="publisher" lang="en">MATE Documentation Project</para>
+                         <para role="author" xml:lang="en">Wolfgang Ulbrich</para>
+                         <para role="publisher" xml:lang="en">MATE Documentation Project</para>
                   </revdescription>
                 </revision>
                 <revision>
-                  <revnumber>Archive Manager Manual V2.26.0</revnumber>
+                  <revnumber>2.26.0</revnumber>
                   <date>March 2009</date>
                   <revdescription>
                          <para role="author">Paul Cutler</para>
@@ -141,7 +129,7 @@
                 </revision>
 				
                 <revision>
-                  <revnumber>Archive Manager Manual V2.24.0</revnumber>
+                  <revnumber>2.24.0</revnumber>
                   <date>July 2008</date>
                   <revdescription>
                          <para role="author">Paolo Bacchilega</para>
@@ -150,7 +138,7 @@
                 </revision>
 				
                 <revision>
-                  <revnumber>Archive Manager Manual V2.6</revnumber>
+                  <revnumber>2.6</revnumber>
                   <date>April 2006</date>
                   <revdescription>
                          <para role="author">Paolo Bacchilega</para>
@@ -159,7 +147,7 @@
                 </revision>
 
                 <revision>
-                  <revnumber>Engrampa Manual V2.5</revnumber>
+                  <revnumber>2.5</revnumber>
                   <date>March 2004</date>
                   <revdescription>
                          <para role="author">Sun GNOME Documentation Team</para>
@@ -167,7 +155,7 @@
                   </revdescription>
                 </revision>
                 <revision>
-                  <revnumber>Engrampa Manual V2.4</revnumber>
+                  <revnumber>2.4</revnumber>
                   <date>February 2004</date>
                   <revdescription>
                          <para role="author">Sun GNOME Documentation Team</para>
@@ -175,7 +163,7 @@
                   </revdescription>
                 </revision>
                 <revision>
-                  <revnumber>Engrampa Manual V2.3</revnumber>
+                  <revnumber>2.3</revnumber>
                   <date>August 2003</date>
                   <revdescription>
                          <para role="author">Sun GNOME Documentation Team</para>
@@ -183,7 +171,7 @@
                   </revdescription>
                 </revision>
                 <revision>
-                  <revnumber>Engrampa Manual V2.2</revnumber>
+                  <revnumber>2.2</revnumber>
                   <date>June 2003</date>
                   <revdescription>
                          <para role="author">Sun GNOME Documentation Team</para>
@@ -191,7 +179,7 @@
                   </revdescription>
                 </revision>
                 <revision>
-                  <revnumber>Engrampa Manual V2.1</revnumber>
+                  <revnumber>2.1</revnumber>
                   <date>January 2003</date>
                   <revdescription>
                          <para role="author">Paolo Bacchilega</para>                         
@@ -199,7 +187,7 @@
                   </revdescription>
                 </revision>
                 <revision>
-                  <revnumber>Engrampa Manual V2.0</revnumber>
+                  <revnumber>2.0</revnumber>
                   <date>June 2002</date>
                   <revdescription>
                          <para role="author">Alexander Kirillov</para>                         
@@ -208,16 +196,9 @@
                 </revision>
          </revhistory>
 
-    <releaseinfo> This manual describes version &appversion; of &appname;.
-    </releaseinfo> 
-    <legalnotice>
-        <title>Feedback</title>
-        <para>To report a bug or make a suggestion regarding the &app; application or this manual, follow the directions in the
-        <ulink url="help:mate-user-guide/feedback" type="help">MATE Feedback Page</ulink>.
-      </para>
-<!-- Translators may also add here feedback address for translations -->
-    </legalnotice>
-  </articleinfo> 
+    <releaseinfo>This manual describes version 1.10 of Archive Manager.</releaseinfo> 
+  </info> 
+
   <indexterm zone="index"> 
     <primary>Engrampa</primary> 
   </indexterm> 
@@ -256,15 +237,15 @@
 <!-- ============= Introduction ============================== -->
 <!-- Use the Introduction section to give a brief overview of what
      the application is and what it does. -->
-  <sect1 id="engrampa-intro"> 
-    <title>Introduction</title> 
-    <para>You can use the &app; application to create, view, modify, or unpack an archive. An archive is a file that acts as a container for other files. An archive can contain many files, folders, and subfolders, usually in compressed form. 
+  <section xml:id="engrampa-intro"><info><title>Introduction</title></info> 
+     
+    <para>You can use the <application>Archive Manager</application> application to create, view, modify, or unpack an archive. An archive is a file that acts as a container for other files. An archive can contain many files, folders, and subfolders, usually in compressed form. 
     </para>
     <para> 
-      &app; provides only a graphical interface, and relies on command-line utilities such as <command>tar</command>, <command>gzip</command>, and <command>bzip2</command> for archive operations. 
+      <application>Archive Manager</application> provides only a graphical interface, and relies on command-line utilities such as <command>tar</command>, <command>gzip</command>, and <command>bzip2</command> for archive operations. 
     </para>
     <para>
-      If you have the appropriate command-line tools installed on your system, &app; supports the archive formats listed in the following table.</para> 
+      If you have the appropriate command-line tools installed on your system, <application>Archive Manager</application> supports the archive formats listed in the following table.</para> 
       <informaltable frame="all">
         <tgroup cols="2" colsep="1" rowsep="1">
           <colspec colname="COLSPEC0" colwidth="50*"/>
@@ -395,23 +376,23 @@
       </informaltable>
     <para>The most common archive format on Linux and Unix-like systems is the tar archive compressed with <command>gzip</command> or <command>bzip2</command>.  </para>
     <para>The most common archive format on Microsoft Windows systems is the archive created with <application>PKZIP</application> or <application>WinZip</application>.  </para>
-    <sect2 id="engrampa-intro-nonarchive">
-      <title>Compressed Non-Archive Files</title> 
+    <section xml:id="engrampa-intro-nonarchive"><info><title>Compressed Non-Archive Files</title></info>
+       
       <para>A compressed non-archive file is a file that is created when you use <command>bzip2</command>, <command>gzip</command>, <command>lzip</command>, <command>lzop</command>, <command>compress</command> or <command>rzip</command> to compress a non-archive file. For example, <filename>file.txt.gz</filename> is created when you use <command>gzip</command> to compress <filename>file.txt</filename>.</para>
-      <para>You can use &app; to create, open and extract a compressed non-archive file.</para> 
-    </sect2>
-  </sect1>
+      <para>You can use <application>Archive Manager</application> to create, open and extract a compressed non-archive file.</para> 
+    </section>
+  </section>
 
 <!-- ============= Getting Started =========================== -->
-  <sect1 id="engrampa-get-start">
-    <title>Getting Started</title>
-    <para>This section provides information on how to start &app;, and describes the &app; user interface.
+  <section xml:id="engrampa-get-start"><info><title>Getting Started</title></info>
+    
+    <para>This section provides information on how to start <application>Archive Manager</application>, and describes the <application>Archive Manager</application> user interface.
     </para>
 
 <!-- ============= To Start Engrampa ============================ -->
-         <sect2 id="engrampa-to-start">
-                <title>To Start &app;</title>
-                <para>You can start &app; in the following ways:</para>
+         <section xml:id="engrampa-to-start"><info><title>To Start <application>Archive Manager</application></title></info>
+                
+                <para>You can start <application>Archive Manager</application> in the following ways:</para>
                 <variablelist>
                 <varlistentry>
                 <term><guimenu>Applications</guimenu> menu</term>
@@ -426,14 +407,14 @@
                 </listitem>
                 </varlistentry>
                 </variablelist>
-        </sect2>
+        </section>
 
-         <sect2 id="engrampa-when-start">
-                <title>When You Start &app;</title>
-                <para>When you start &app;, the following window is displayed:</para>
+         <section xml:id="engrampa-when-start"><info><title>When You Start <application>Archive Manager</application></title></info>
+                
+                <para>When you start <application>Archive Manager</application>, the following window is displayed:</para>
 
-                <figure id="engrampa-FIG-main-window">
-                  <title>&app; Window</title>
+                <figure xml:id="engrampa-FIG-main-window"><info><title><application>Archive Manager</application> Window</title></info>
+                  
                   <screenshot>
                          <mediaobject>
                                 <imageobject>
@@ -445,21 +426,21 @@
                   </screenshot>
                 </figure>
 
-                <para>The &app; window contains the following elements: </para>
+                <para>The <application>Archive Manager</application> window contains the following elements: </para>
                 <variablelist>
                   <varlistentry> <term>Menubar</term>
                          <listitem>
-                                <para>The menus on the menubar contain all of the commands that you need to work with archives in &app;.</para>
+                                <para>The menus on the menubar contain all of the commands that you need to work with archives in <application>Archive Manager</application>.</para>
                          </listitem>
                   </varlistentry>
                   <varlistentry> <term>Toolbar</term>
                          <listitem>
-                                <para>The toolbar contains a subset of the commands that you can access from the menubar. &app; displays the toolbar by default. To hide the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice>. To show the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice> again. </para>
+                                <para>The toolbar contains a subset of the commands that you can access from the menubar. <application>Archive Manager</application> displays the toolbar by default. To hide the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice>. To show the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice> again. </para>
                          </listitem>
                   </varlistentry>
                   <varlistentry> <term>Folderbar</term>
                          <listitem>
-                                <para>The folderbar enables you to navigate among folders within an archive. &app; displays the folderbar only in folder view. See <xref linkend="engrampa-view-type-folder"/> for more information.</para>
+                                <para>The folderbar enables you to navigate among folders within an archive. <application>Archive Manager</application> displays the folderbar only in folder view. See <xref linkend="engrampa-view-type-folder"/> for more information.</para>
                          </listitem>
                   </varlistentry>
                   <varlistentry> <term>Display area</term>
@@ -469,38 +450,37 @@
                   </varlistentry>
                   <varlistentry> <term>Statusbar</term>
                          <listitem>
-                                <para>The statusbar displays information about current &app; activity and contextual information about the archive contents. &app; displays the statusbar by default. To hide the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice>. To show the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice> again. </para>
+                                <para>The statusbar displays information about current <application>Archive Manager</application> activity and contextual information about the archive contents. <application>Archive Manager</application> displays the statusbar by default. To hide the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice>. To show the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice> again. </para>
                          </listitem>
                   </varlistentry>
                 </variablelist>
-                <para>When you right-click in the &app; window, the application displays a popup menu. The popup menu contains the most common contextual archive commands. </para>
+                <para>When you right-click in the <application>Archive Manager</application> window, the application displays a popup menu. The popup menu contains the most common contextual archive commands. </para>
 
-     <sect3 id="engrampa-bookmarks">
-        <title>Browsing the Filesystem</title>
-        <para>Several &app; dialogs (<guilabel>New</guilabel>, <guilabel>Open</guilabel>, <guilabel>Extract</guilabel>,...) enable you
-        to browse files and folders on your computer. Refer to the <ulink type="help" 
-        url="help:mate-user-guide/filechooser-open">Desktop User Guide</ulink> to learn more about using the 
+     <section xml:id="engrampa-bookmarks"><info><title>Browsing the Filesystem</title></info>
+        
+        <para>Several <application>Archive Manager</application> dialogs (<guilabel>New</guilabel>, <guilabel>Open</guilabel>, <guilabel>Extract</guilabel>,...) enable you
+        to browse files and folders on your computer. Refer to the <link xlink:href="help:mate-user-guide/filechooser-open">Desktop User Guide</link> to learn more about using the 
         file browsing dialogs.</para>
-        <para>You can also refer to the <ulink type="help" url="help:mate-user-guide/caja-bookmarks">Bookmarks 
-        section</ulink> of the Desktop User Guide to learn how you can use the <guilabel>Places</guilabel> pane 
+        <para>You can also refer to the <link xlink:href="help:mate-user-guide/caja-bookmarks">Bookmarks 
+        section</link> of the Desktop User Guide to learn how you can use the <guilabel>Places</guilabel> pane 
         to access your favorite locations.</para>
-     </sect3>
-   </sect2>
-</sect1>
+     </section>
+   </section>
+</section>
 
 
 
 <!-- ======= Working with archives ============= --> 
 
-<sect1 id="engrampa-working">
-      <title>Working With Archives</title>
+<section xml:id="engrampa-working"><info><title>Working With Archives</title></info>
+      
       <para>
-        When you use &app; to work with an archive, all changes are saved to disk immediately. For example, if you delete a file from an archive, &app; deletes the file as soon as you click <guibutton>OK</guibutton>. This behavior is different to that of most applications, which save the changes to disk only when you quit the application or select <guimenuitem>Save</guimenuitem> in the menu.</para>
+        When you use <application>Archive Manager</application> to work with an archive, all changes are saved to disk immediately. For example, if you delete a file from an archive, <application>Archive Manager</application> deletes the file as soon as you click <guibutton>OK</guibutton>. This behavior is different to that of most applications, which save the changes to disk only when you quit the application or select <guimenuitem>Save</guimenuitem> in the menu.</para>
       <para>
 	If an archive is very large, or you have a slow system, some archive actions can take significant time. To abort the current action, press <keycap>Esc</keycap>. Alternatively, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Stop</guimenuitem></menuchoice>, or click <guibutton>Stop</guibutton> in the toolbar. 
       </para>      
       <para>
-        In &app;, you can perform the same action in several ways. For example, you can open an archive in the following ways:
+        In <application>Archive Manager</application>, you can perform the same action in several ways. For example, you can open an archive in the following ways:
                   <informaltable frame="all">
                     <tgroup cols="2" colsep="1" rowsep="1">
                       <colspec colname="COLSPEC0" colwidth="50*"/>
@@ -516,7 +496,7 @@
                       <tbody>
                         <row valign="top">               
                           <entry><para>Window</para></entry>
-                          <entry><para>Drag an archive into the &app; window from another application such as a file manager.</para></entry>
+                          <entry><para>Drag an archive into the <application>Archive Manager</application> window from another application such as a file manager.</para></entry>
                         </row>
                         <row valign="top">               
                           <entry><para>Menubar</para></entry>
@@ -545,9 +525,9 @@
       This manual documents functionality from the menubar.
       </para>
 
-    <sect2 id="engrampa-pattern">
-      <title>Filename Patterns</title>
-      <para>&app; enables you to add, extract, or delete several files at once. To apply an action to all files that match a certain pattern, enter the pattern in the text box. The pattern can include standard wildcard symbols such as <keycap>*</keycap> to match any string, and <keycap>?</keycap> to match any single symbol. You can enter several patterns separated by semicolons. &app; applies the action to all files that match at least one of the patterns. The examples in the following table show how to use filename patterns to select files.
+    <section xml:id="engrampa-pattern"><info><title>Filename Patterns</title></info>
+      
+      <para><application>Archive Manager</application> enables you to add, extract, or delete several files at once. To apply an action to all files that match a certain pattern, enter the pattern in the text box. The pattern can include standard wildcard symbols such as <keycap>*</keycap> to match any string, and <keycap>?</keycap> to match any single symbol. You can enter several patterns separated by semicolons. <application>Archive Manager</application> applies the action to all files that match at least one of the patterns. The examples in the following table show how to use filename patterns to select files.
       </para>
       <informaltable frame="all">
         <tgroup cols="2" colsep="1" rowsep="1">
@@ -581,15 +561,15 @@
           </tbody>
         </tgroup>
       </informaltable>
-    </sect2>
+    </section>
 
 <!-- ======= To open an archive ============= --> 
 
-<sect2 id="engrampa-open">
-      <title>To Open an Archive</title>
+<section xml:id="engrampa-open"><info><title>To Open an Archive</title></info>
+      
       <para>
 	To open an archive, perform the following steps:
-        <orderedlist>
+        <orderedlist inheritnum="ignore" continuation="restarts">
           <listitem>
            <para>Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Open</guimenuitem></menuchoice> to display the <guilabel>Open</guilabel> dialog. Alternatively press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap></keycombo>, or click <guibutton>Open</guibutton> in the toolbar.</para> 
           </listitem>
@@ -601,7 +581,7 @@
           </listitem>
         </orderedlist>
       </para>
-      <para>&app; automatically determines the archive type, and displays:
+      <para><application>Archive Manager</application> automatically determines the archive type, and displays:
         <itemizedlist>
           <listitem>
             <para>The archive name in the window titlebar</para>
@@ -615,29 +595,29 @@
         </itemizedlist>
       </para>
       <para>
-        To open another archive, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Open</guimenuitem></menuchoice> again. &app; opens each archive in a new window. You can't open another archive in the same window.
+        To open another archive, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Open</guimenuitem></menuchoice> again. <application>Archive Manager</application> opens each archive in a new window. You can't open another archive in the same window.
       </para>
       <para>
-	If you try to open an archive that was created in a format that &app; does not recognize, the application displays an error message. See <xref linkend="engrampa-intro"/> for a list of supported formats.
+	If you try to open an archive that was created in a format that <application>Archive Manager</application> does not recognize, the application displays an error message. See <xref linkend="engrampa-intro"/> for a list of supported formats.
       </para>
-  </sect2>
+  </section>
 
 <!-- ======= Selecting files in an archive  ============= --> 
-    <sect2 id="engrampa-select-files">
-      <title>To Select Files in an Archive</title>
+    <section xml:id="engrampa-select-files"><info><title>To Select Files in an Archive</title></info>
+      
     <para>
       To select all files in an archive, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Select All</guimenuitem></menuchoice> or press <keycombo><keycap>Ctrl</keycap><keycap>A</keycap></keycombo>. </para>
       <para>To deselect all files in an archive, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Deselect All</guimenuitem></menuchoice> or press <keycombo><keycap>Shift</keycap><keycap>Ctrl</keycap><keycap>A</keycap></keycombo>.
     </para>
-    </sect2>
+    </section>
 
   <!-- =========== Extracting Files From an Archive ==================== -->
 
-  <sect2 id="engrampa-extract"> 
-    <title>To Extract Files From an Archive</title> 
+  <section xml:id="engrampa-extract"><info><title>To Extract Files From an Archive</title></info> 
+     
     <para>
 	To extract files from an open archive, perform the following steps:
-        <orderedlist>
+        <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem><para>
         Select the files that you want to extract.  To select more files, press-and-hold <keycap>Ctrl</keycap> and click on the files you want to select.</para>
         </listitem>
@@ -645,7 +625,7 @@
         Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Extract</guimenuitem></menuchoice> to display the <guilabel>Extract</guilabel> dialog.  Alternatively click <guibutton>Extract</guibutton> in the toolbar.</para>
         </listitem>
         <listitem><para>
-        Select the folder where &app; extracts the files.</para>
+        Select the folder where <application>Archive Manager</application> extracts the files.</para>
         </listitem>
         <listitem><para>
         Select the required extract options. For more information about the extract options, see <xref linkend="engrampa-extract-options"/>.</para>
@@ -654,10 +634,10 @@
         Click <guibutton>Extract</guibutton>.</para>
         <note>
           <para>
-            If all of the files in the archive are protected by a password, and you have not specified it, &app; asks you to enter the password.
+            If all of the files in the archive are protected by a password, and you have not specified it, <application>Archive Manager</application> asks you to enter the password.
           </para>
           <para>
-            If some but not all of the files in the archive are protected by a password, and you have not specified the password, &app; does not ask for a password. However, &app; extracts only the unprotected files.
+            If some but not all of the files in the archive are protected by a password, and you have not specified the password, <application>Archive Manager</application> does not ask for a password. However, <application>Archive Manager</application> extracts only the unprotected files.
           </para>
           <para>
             For more information about passwords, see <xref linkend="engrampa-encrypt-files"/>.
@@ -666,44 +646,44 @@
         </listitem>
         </orderedlist>
         </para>
-      <para>&app; also provides ways of extracting files from an archive in a file manager window, without opening a &app; window. See <xref linkend="engrampa-fmgr"/> for more information.</para>
+      <para><application>Archive Manager</application> also provides ways of extracting files from an archive in a file manager window, without opening a <application>Archive Manager</application> window. See <xref linkend="engrampa-fmgr"/> for more information.</para>
     <para>
       The Extract operation extracts a <emphasis>copy</emphasis> of the specified files from the archive. The extracted files have the same permissions and modification date as the original files that were added to the archive.
     </para>
     <para>
       The Extract operation does not change the contents of the archive. For information on how to delete files from an archive, see <xref linkend="engrampa-delete-files"/>. 
     </para>
-  </sect2>
+  </section>
     
 <!-- ======= Closing the Archive ============= --> 
-  <sect2 id="engrampa-archive-close">
-    <title>To Close an Archive</title>
-    <para>To close the current archive and the current &app; window, choose <menuchoice> <guimenu>Archive</guimenu> <guimenuitem>Close</guimenuitem> </menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>.
+  <section xml:id="engrampa-archive-close"><info><title>To Close an Archive</title></info>
+    
+    <para>To close the current archive and the current <application>Archive Manager</application> window, choose <menuchoice> <guimenu>Archive</guimenu> <guimenuitem>Close</guimenuitem> </menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>.
     </para>
     <note>
-      <para>There is no way to close the current archive but not the &app; window.
+      <para>There is no way to close the current archive but not the <application>Archive Manager</application> window.
       </para>
     </note>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
 
 <!-- =============  Creating Archives ============================= -->
-<sect1 id="engrampa-creating"> 
-    <title>Creating Archives</title> 
+<section xml:id="engrampa-creating"><info><title>Creating Archives</title></info> 
+     
     <para>
-      In addition to opening existing archives, you can also create new archives with &app;.</para>
-    <sect2 id="engrampa-create"> 
-    <title>To Create an Archive</title> 
+      In addition to opening existing archives, you can also create new archives with <application>Archive Manager</application>.</para>
+    <section xml:id="engrampa-create"><info><title>To Create an Archive</title></info> 
+     
     <para>
       To create an archive, perform the following steps:
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem>
           <para>Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>New</guimenuitem></menuchoice> to display the <guilabel>New</guilabel> dialog.  Alternatively press <keycombo><keycap>Ctrl</keycap><keycap>N</keycap></keycombo>, or click <guibutton>New</guibutton> in the toolbar.
           </para>
         </listitem>
         <listitem>
-          <para>Specify the folder where &app; places the new archive clicking on the entry in the <guilabel>Save in folder</guilabel> drop-down list. If the folder is not present in list, click on <guilabel>Browse for other folders</guilabel>, and select the folder. Alternatively, enter the path in the <guilabel>Name</guilabel> text box.
+          <para>Specify the folder where <application>Archive Manager</application> places the new archive clicking on the entry in the <guilabel>Save in folder</guilabel> drop-down list. If the folder is not present in list, click on <guilabel>Browse for other folders</guilabel>, and select the folder. Alternatively, enter the path in the <guilabel>Name</guilabel> text box.
           </para>
         </listitem>
         <listitem>
@@ -714,27 +694,27 @@
         Select the required create options clicking on <guilabel>Other Options</guilabel>. For more information about the create options, see <xref linkend="engrampa-create-options"/>.</para>
         </listitem>
         <listitem>
-          <para>Click <guibutton>New</guibutton>. &app; creates an empty archive, but does not yet write the archive to disk. 
+          <para>Click <guibutton>New</guibutton>. <application>Archive Manager</application> creates an empty archive, but does not yet write the archive to disk. 
           </para>
         </listitem>
         <listitem>
           <para>Add files to the new archive as described in <xref linkend="engrampa-add-files"/>.  
                 <note>
-                  <para>&app; writes a new archive to disk only when the archive contains at least one file. If you create a new archive and quit &app; before you add any files to the archive, &app; deletes the archive.
+                  <para><application>Archive Manager</application> writes a new archive to disk only when the archive contains at least one file. If you create a new archive and quit <application>Archive Manager</application> before you add any files to the archive, <application>Archive Manager</application> deletes the archive.
                   </para>
                 </note>
           </para>
         </listitem>
       </orderedlist>
     </para>
-</sect2>
+</section>
 
     <!-- ======= Adding files to an archive  ============= --> 
-  <sect2 id="engrampa-add-files">
-    <title>To Add Files to an Archive</title>
+  <section xml:id="engrampa-add-files"><info><title>To Add Files to an Archive</title></info>
+    
     <para>
       To add files to an archive, perform the following steps:
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
          <listitem>
            <para>Decide where in the archive you want to add the files, then open that location in the archive.</para> 
          </listitem>
@@ -745,24 +725,24 @@
            <para>Select the files that you want to add.  To select more files press-and-hold <keycap>Ctrl</keycap> and click the files.</para> 
          </listitem>
          <listitem>
-           <para>Click <guibutton>Add</guibutton>. &app; adds the files to the current folder in the archive.
+           <para>Click <guibutton>Add</guibutton>. <application>Archive Manager</application> adds the files to the current folder in the archive.
           </para> 
          </listitem>
       </orderedlist>
     </para>
     <para>You cannot add folders to the archive with the <guilabel>Add Files</guilabel> dialog. To add a folder see <xref linkend="engrampa-add-folder"/>.</para>
     <para>The <guilabel>Add Files</guilabel> dialog provides the <guilabel>Add only if newer</guilabel> option, see <xref linkend="engrampa-add-options"/> for more information on this option.</para>
-    <para>You can also add files to an archive in a file manager window, without opening an &app; window. See <xref linkend="engrampa-fmgr"/> for more information.</para>
-    <para>The Add operation adds a <emphasis>copy</emphasis> of the specified files or folders to the archive. &app; does not remove the original files, which remain unchanged in the file system. The copies that are added to the archive have the same permissions and modification date as the original files. 
+    <para>You can also add files to an archive in a file manager window, without opening an <application>Archive Manager</application> window. See <xref linkend="engrampa-fmgr"/> for more information.</para>
+    <para>The Add operation adds a <emphasis>copy</emphasis> of the specified files or folders to the archive. <application>Archive Manager</application> does not remove the original files, which remain unchanged in the file system. The copies that are added to the archive have the same permissions and modification date as the original files. 
     </para>
-    </sect2>
+    </section>
 
 <!-- ======= Adding files - Adding folder  ============= --> 
-    <sect2 id="engrampa-add-folder">
-      <title>To Add a Folder to an Archive</title>
+    <section xml:id="engrampa-add-folder"><info><title>To Add a Folder to an Archive</title></info>
+      
     <para>
       To add a folder to an archive, perform the following steps:
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
          <listitem>
            <para>Decide where in the archive you want to add the files, then open that location in the archive.</para>
          </listitem>
@@ -773,20 +753,20 @@
            <para>Select the folder that you want to add.</para> 
          </listitem>
          <listitem>
-           <para>Click <guibutton>Add</guibutton>. &app; adds the folder to the current folder in the archive.
+           <para>Click <guibutton>Add</guibutton>. <application>Archive Manager</application> adds the folder to the current folder in the archive.
           </para> 
          </listitem>
       </orderedlist>
     </para>
     <para>The <guilabel>Add a Folder</guilabel> dialog provides several advanced options. See <xref linkend="engrampa-add-options"/> for more information.</para>
-    </sect2>
+    </section>
 
   <!-- ======= Converting an Archive to Another Format ============= --> 
-  <sect2 id="engrampa-convert-archive">
-    <title>To Convert an Archive to Another Format</title>
+  <section xml:id="engrampa-convert-archive"><info><title>To Convert an Archive to Another Format</title></info>
+    
     <para>To convert an archive to another format and save as a new file, perform the following steps:
     </para>
-    <orderedlist>
+    <orderedlist inheritnum="ignore" continuation="restarts">
       <listitem>
         <para>Open the archive that you want to convert.
         </para>
@@ -812,10 +792,10 @@
         </para>
         <note>
           <para>
-            If all of the files in the archive are protected by a password, and you have not specified it, &app; asks you to enter the password.
+            If all of the files in the archive are protected by a password, and you have not specified it, <application>Archive Manager</application> asks you to enter the password.
           </para>
           <para>
-            If some but not all of the files in the archive are protected by a password, and you have not specified the password, &app; does not ask for a password. However, &app; copies only the unprotected files to the new archive.
+            If some but not all of the files in the archive are protected by a password, and you have not specified the password, <application>Archive Manager</application> does not ask for a password. However, <application>Archive Manager</application> copies only the unprotected files to the new archive.
           </para>
           <para>
             For more information about passwords, see <xref linkend="engrampa-encrypt-files"/>.
@@ -823,45 +803,45 @@
         </note>
       </listitem>
     </orderedlist>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
 <!-- ======= Operations on Archive Contents ============= --> 
-<sect1 id="engrampa-modify-contents">
-  <title>Modifying the Contents of an Archive</title>
+<section xml:id="engrampa-modify-contents"><info><title>Modifying the Contents of an Archive</title></info>
+  
   <para>
     You can modify the contents of an archive in several ways.
   </para>
 
 <!-- ======= Encrypting files in an archive  ============= --> 
-    <sect2 id="engrampa-encrypt-files">
-      <title>To Encrypt Files in an Archive</title>
+    <section xml:id="engrampa-encrypt-files"><info><title>To Encrypt Files in an Archive</title></info>
+      
     <para>For security, you might want to encrypt the files that you add to an archive. </para>
       <para>If the archive format supports encryption, you can specify a password to encrypt the files that you add to the archive.</para>
       <note>
         <para>Currently, only 7-Zip, ZIP, RAR and ARJ archives support encryption.</para>
       </note>
      <para>To specify a password for file encryption, perform the following steps:</para>
-       <orderedlist>
+       <orderedlist inheritnum="ignore" continuation="restarts">
           <listitem><para>Choose <menuchoice><guimenu>Edit</guimenu> <guimenuitem>Password</guimenuitem></menuchoice> to display the <guilabel>Password</guilabel> dialog.</para></listitem> 
 <listitem><para>Enter the password in the <guilabel>Password</guilabel> text box.</para></listitem>
 <listitem><para>Click <guibutton>OK</guibutton>.</para></listitem>
        </orderedlist>
-    <para>&app; uses the password to encrypt the files that you add to the current archive, and to decrypt the files that you extract from the current archive. &app; deletes the password when you close the archive.
+    <para><application>Archive Manager</application> uses the password to encrypt the files that you add to the current archive, and to decrypt the files that you extract from the current archive. <application>Archive Manager</application> deletes the password when you close the archive.
       </para>
       <para>For information on how to check whether an archive contains encrypted files, see <xref linkend="engrampa-extra-info"/>.
       </para>
       <note>
-      <para>The encryption provided by archive utilities is weak and insecure. If security is important, use a strong encryption tool such as <ulink url="http://www.gnupg.org" type="http">GNU Privacy Guard</ulink>.
+      <para>The encryption provided by archive utilities is weak and insecure. If security is important, use a strong encryption tool such as <link xlink:href="http://www.gnupg.org">GNU Privacy Guard</link>.
       </para>
       </note>
-    </sect2>
+    </section>
 
 <!-- ======= Renaming files in an archive  ============= --> 
-  <sect2 id="engrampa-rename-files">
-    <title>To Rename a File in an Archive</title>
+  <section xml:id="engrampa-rename-files"><info><title>To Rename a File in an Archive</title></info>
+    
     <para>To rename a file in an archive, perform the following steps:</para>
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem>
           <para>Select the file that you want to rename.</para>
         </listitem>
@@ -876,13 +856,13 @@
           </para>
         </listitem>
       </orderedlist>
-  </sect2>
+  </section>
 
 <!-- ======= Copying files in an archive  ============= --> 
-  <sect2 id="engrampa-copy-files">
-    <title>To Copy Files in an Archive</title>
+  <section xml:id="engrampa-copy-files"><info><title>To Copy Files in an Archive</title></info>
+    
     <para>To copy files in an archive, perform the following steps:</para>
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem>
           <para>Select the files that you want to copy.</para>
         </listitem>
@@ -896,13 +876,13 @@
           <para>Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste</guimenuitem></menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>V</keycap></keycombo>.  </para>
         </listitem>
       </orderedlist>
-  </sect2>
+  </section>
 
 <!-- ======= Moving files in an archive  ============= --> 
-  <sect2 id="engrampa-move-files">
-    <title>To Move Files in an Archive</title>
+  <section xml:id="engrampa-move-files"><info><title>To Move Files in an Archive</title></info>
+    
     <para>To move files in an archive, perform the following steps:</para>
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem>
           <para>Select the files that you want to move.</para>
         </listitem>
@@ -916,13 +896,13 @@
           <para>Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste</guimenuitem></menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>V</keycap></keycombo>.  </para>
         </listitem>
       </orderedlist>
-  </sect2>
+  </section>
 
 <!-- ======= Deleting files from an archive  ============= --> 
-  <sect2 id="engrampa-delete-files">
-    <title>To Delete Files From an Archive</title>
+  <section xml:id="engrampa-delete-files"><info><title>To Delete Files From an Archive</title></info>
+    
     <para>To delete files from an archive, perform the following steps:</para>
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem>
           <para>Select the files that you want to delete.</para>
         </listitem>
@@ -963,47 +943,47 @@
           </para>
         </listitem>
       </orderedlist>
-  </sect2>
+  </section>
 
 <!-- =============  Modify a File in an Archive ==================== -->
-  <sect2 id="engrampa-modify-archive-file"> 
-    <title>To Modify a File in an Archive</title> 
+  <section xml:id="engrampa-modify-archive-file"><info><title>To Modify a File in an Archive</title></info> 
+     
     <para>
       To modify a file in an archive perform the following steps:
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
       <listitem><para>Double-click the file that you want to open. Alternatively right-click the file and choose <menuchoice><guimenuitem>Open</guimenuitem></menuchoice>.</para></listitem>
       <listitem><para>Edit the file opened in step 1, and then save your changes.</para></listitem>
-      <listitem><para>&app; shows a confirmation dialog, asking confirmation to update the file in the archive with the changes you made.</para></listitem>
+      <listitem><para><application>Archive Manager</application> shows a confirmation dialog, asking confirmation to update the file in the archive with the changes you made.</para></listitem>
       <listitem><para>Click on <guilabel>Update</guilabel>.</para></listitem>
       </orderedlist>
     </para>
-    <para>&app; uses the system-defined associations between file types and programs to determine the appropriate application to launch for a specific file. These assocations can be displayed and modified in the <guilabel>Open With</guilabel> tab of the file properties dialog. If &app; cannot determine the appropriate application, &app; displays the <guilabel>Open Files</guilabel> dialog to let you choose an application, as described in below.
+    <para><application>Archive Manager</application> uses the system-defined associations between file types and programs to determine the appropriate application to launch for a specific file. These assocations can be displayed and modified in the <guilabel>Open With</guilabel> tab of the file properties dialog. If <application>Archive Manager</application> cannot determine the appropriate application, <application>Archive Manager</application> displays the <guilabel>Open Files</guilabel> dialog to let you choose an application, as described in below.
     </para>
-    <sect3 id="engrampa-modifiy-archive-file-custom-app">
-    <title>To Modify a File in an Archive with a Custom Application</title>
+    <section xml:id="engrampa-modifiy-archive-file-custom-app"><info><title>To Modify a File in an Archive with a Custom Application</title></info>
+    
     <para>
       You can use an application specified by you, rather than the default application, to modify a file. To use an external application to open a file:
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
       <listitem><para>Right click the file.</para></listitem>
       <listitem><para>Choose <menuchoice><guimenuitem>Open With...</guimenuitem></menuchoice>.</para></listitem>
       </orderedlist>
     </para>    
-    <para>&app; displays the <guilabel>Open Files</guilabel> dialog, which lists all of the applications that can open files of the specified type. To select one of the applications, double-click the application name or click on the application name and then click <guibutton>Open</guibutton>. Alternatively, enter the application name in the <guilabel>Application</guilabel> text box and then click <guibutton>Open</guibutton> to launch the application of your choice.</para>
+    <para><application>Archive Manager</application> displays the <guilabel>Open Files</guilabel> dialog, which lists all of the applications that can open files of the specified type. To select one of the applications, double-click the application name or click on the application name and then click <guibutton>Open</guibutton>. Alternatively, enter the application name in the <guilabel>Application</guilabel> text box and then click <guibutton>Open</guibutton> to launch the application of your choice.</para>
     <para>Once the application starts follow the procedure from step 2 as described in <xref linkend="engrampa-modify-archive-file"/>.</para>
-    </sect3>
-  </sect2>
-</sect1>
+    </section>
+  </section>
+</section>
 
 
 <!-- ======= Viewing an archive ============= --> 
-<sect1 id="engrampa-view">
-  <title>Viewing Archives</title>
-  <para>&app; enables you to view several aspects of an archive.
+<section xml:id="engrampa-view"><info><title>Viewing Archives</title></info>
+  
+  <para><application>Archive Manager</application> enables you to view several aspects of an archive.
   </para>
 
 <!-- ======= Archive Properties ============= --> 
-    <sect2 id="engrampa-view-archive-properties">
-      <title>To View the Properties of an Archive</title>
+    <section xml:id="engrampa-view-archive-properties"><info><title>To View the Properties of an Archive</title></info>
+      
       <para>To view the properties of an archive, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Properties</guimenuitem></menuchoice> to display the <guilabel>Properties</guilabel> dialog. The <guilabel>Properties</guilabel> dialog displays the following information about the archive:
             <variablelist>
 	      <varlistentry>
@@ -1045,14 +1025,14 @@
 	      </varlistentry>
             </variablelist>
       </para>
-    </sect2>
+    </section>
  
 
 <!-- ======= Archive Contents ============= --> 
-    <sect2 id="engrampa-view-archive-contents">
-      <title>To View the Contents of an Archive</title>
+    <section xml:id="engrampa-view-archive-contents"><info><title>To View the Contents of an Archive</title></info>
+      
 
-      <para> &app; displays the archive contents in the main window as a file list with the following columns:
+      <para> <application>Archive Manager</application> displays the archive contents in the main window as a file list with the following columns:
         <variablelist>
 	  <varlistentry>
 	    <term><guilabel>Name</guilabel></term>
@@ -1081,57 +1061,57 @@
 	  </varlistentry>
         </variablelist>
       </para>
-      <para>If another program has modified the archive since &app; opened the archive, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reload</guimenuitem></menuchoice> to reload the archive contents from disk.
+      <para>If another program has modified the archive since <application>Archive Manager</application> opened the archive, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reload</guimenuitem></menuchoice> to reload the archive contents from disk.
       </para>
-      <para>For information on how to customize the way that &app; displays the archive contents, see <xref linkend="engrampa-archive-custom"/>.
+      <para>For information on how to customize the way that <application>Archive Manager</application> displays the archive contents, see <xref linkend="engrampa-archive-custom"/>.
       </para>
       <para>For more advanced tasks, use an application installed on your system. For more information, see <xref linkend="engrampa-view-archive-file"/>. 
       </para>
-    </sect2>
+    </section>
 
   <!-- =============  Viewing a File in an Archive ==================== -->
-  <sect2 id="engrampa-view-archive-file"> 
-    <title>To View a File in an Archive</title> 
+  <section xml:id="engrampa-view-archive-file"><info><title>To View a File in an Archive</title></info> 
+     
     <para>
-      To view a file in an archive follow the steps described in <xref linkend="engrampa-modify-archive-file"/>.  If you save the opened file, click <guilabel>Cancel</guilabel> when &app; asks confirmation to update the file in the archive.
+      To view a file in an archive follow the steps described in <xref linkend="engrampa-modify-archive-file"/>.  If you save the opened file, click <guilabel>Cancel</guilabel> when <application>Archive Manager</application> asks confirmation to update the file in the archive.
     </para>
-  </sect2>
+  </section>
 
 <!-- =============  Testing the Integrity of an Archive ==================== -->
-  <sect2 id="engrampa-test-archive"> 
-    <title>To Test the Integrity of an Archive</title> 
+  <section xml:id="engrampa-test-archive"><info><title>To Test the Integrity of an Archive</title></info> 
+     
     <para>Sometimes an archive can be damaged for some reason, to check whether an archive is damaged, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Test Integrity</guimenuitem></menuchoice>:
             <itemizedlist>
               <listitem>
-                <para>If the archive contains no errors, &app; opens the <guilabel>Test Result</guilabel> dialog to list each file in the archive, and indicates that each file has status <literal>OK</literal>.
+                <para>If the archive contains no errors, <application>Archive Manager</application> opens the <guilabel>Test Result</guilabel> dialog to list each file in the archive, and indicates that each file has status <literal>OK</literal>.
                 </para>
               </listitem>
               <listitem>
-                <para>If the archive contains some error, &app; opens the <guilabel>Test Result</guilabel> dialog displaying the part of the archive contains the error.
+                <para>If the archive contains some error, <application>Archive Manager</application> opens the <guilabel>Test Result</guilabel> dialog displaying the part of the archive contains the error.
                 </para>
               </listitem>
             </itemizedlist>
     </para>
     <para>A damaged archive can be impossible to extract, this can bring to a loss of data.  For this reason you should test the archive integrity before deleting the original files.
     </para>
-    <para>If the archive contains encrypted files, &app; asks the password of the archive before performing the test.
+    <para>If the archive contains encrypted files, <application>Archive Manager</application> asks the password of the archive before performing the test.
     </para>
     <note>
       <para>Not all the archive types support the integrity testing, the following is the list of archive types that can be tested for integrity: 7-Zip, RAR, ZIP, ACE, ARJ and Zoo.
       </para>
     </note>
-    <tip>
-      <title>Tip</title>
+    <tip><info><title>Tip</title></info>
+      
       <para>To test the integrity of an archive that doesn't support the integrity testing, extract all the files from the archive and check that the operation is completed successfully.      
       </para>      
     </tip>
-  </sect2>  
-</sect1>
+  </section>  
+</section>
     
 <!-- ======= Customizing the Archive Display ============= --> 
-<sect1 id="engrampa-archive-custom">
-  <title>Customizing the Archive Display</title>
-  <para>You can customize the way that &app; displays the archive contents, as follows:
+<section xml:id="engrampa-archive-custom"><info><title>Customizing the Archive Display</title></info>
+  
+  <para>You can customize the way that <application>Archive Manager</application> displays the archive contents, as follows:
   </para>
   <itemizedlist>
     <listitem>
@@ -1147,21 +1127,21 @@
       </para>
     </listitem> 
   </itemizedlist>
-  <para>&app; updates the display immediately, when you make any of the above customizations.
+  <para><application>Archive Manager</application> updates the display immediately, when you make any of the above customizations.
   </para>
 
-  <sect2 id="engrampa-view-type">
-    <title>To Set the View Type</title>
+  <section xml:id="engrampa-view-type"><info><title>To Set the View Type</title></info>
+    
     <para>If the archive contains folders, you can show the archive contents in either <link linkend="engrampa-view-type-folder">folder view</link> or <link linkend="engrampa-view-type-file">file view</link>. 
     </para>
 
-    <sect3 id="engrampa-view-type-folder">
-      <title>Folder View</title>
-      <para>&app; displays the archive contents in folder view by default. To explicitly select folder view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>View as a Folder</guimenuitem></menuchoice>.
+    <section xml:id="engrampa-view-type-folder"><info><title>Folder View</title></info>
+      
+      <para><application>Archive Manager</application> displays the archive contents in folder view by default. To explicitly select folder view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>View as a Folder</guimenuitem></menuchoice>.
       </para>
-      <para>In folder view, &app; shows folders in the same way as a file manager shows folders. That is, &app; indicates folders in the display area with a folder icon and the folder name. To view the contents of a folder, double-click on the folder name.  
+      <para>In folder view, <application>Archive Manager</application> shows folders in the same way as a file manager shows folders. That is, <application>Archive Manager</application> indicates folders in the display area with a folder icon and the folder name. To view the contents of a folder, double-click on the folder name.  
       </para>
-      <para>The folderbar, which &app; displays only in folder view, contains the components described in the following table.
+      <para>The folderbar, which <application>Archive Manager</application> displays only in folder view, contains the components described in the following table.
       </para>
       <informaltable frame="all">
         <tgroup cols="2" colsep="1" rowsep="1">
@@ -1262,77 +1242,77 @@
                 <para>
                   This field shows the full pathname, within the archive, of the current folder.
                 </para>
-                <para>To change to a different level in the folder tree, type the new location in the <guilabel>Location</guilabel> text box then press <keycap>Return</keycap>. &app; displays the contents of the new location.
+                <para>To change to a different level in the folder tree, type the new location in the <guilabel>Location</guilabel> text box then press <keycap>Return</keycap>. <application>Archive Manager</application> displays the contents of the new location.
                 </para>
               </entry>
             </row>
           </tbody>
         </tgroup>
       </informaltable>
-    </sect3>
+    </section>
 
-    <sect3 id="engrampa-view-type-file">
-      <title>File View</title>
+    <section xml:id="engrampa-view-type-file"><info><title>File View</title></info>
+      
       <para>To select file view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>View All Files</guimenuitem></menuchoice>.
       </para>
-      <para>In file view, &app; displays all files in the archive, including files from subfolders, in a single list. 
+      <para>In file view, <application>Archive Manager</application> displays all files in the archive, including files from subfolders, in a single list. 
       </para>
-    </sect3>
+    </section>
 
-  </sect2>
+  </section>
 
-  <sect2 id="engrampa-view-sort">
-    <title>To Sort the File List</title>
+  <section xml:id="engrampa-view-sort"><info><title>To Sort the File List</title></info>
+    
     <para>You can sort the file list by name, size, type, modification date, or location. </para>
     <para>To specify a sort order, click on the heading of the corresponding column. </para>
     <para>To reverse the sort order, click on the column heading again.
     </para>
-    <para>For example, to sort the file list by modification date, click on the <guilabel>Date modified</guilabel> heading. &app; rearranges the file list to display the files by modification date, starting with the earliest. To display the latest files first, click on the <guilabel>Date modified</guilabel> heading again.
+    <para>For example, to sort the file list by modification date, click on the <guilabel>Date modified</guilabel> heading. <application>Archive Manager</application> rearranges the file list to display the files by modification date, starting with the earliest. To display the latest files first, click on the <guilabel>Date modified</guilabel> heading again.
 	  </para>
-    <para>&app; always performs a secondary sort based on the file name. In the above example, &app; sorts by name any files that have the same modification date.
+    <para><application>Archive Manager</application> always performs a secondary sort based on the file name. In the above example, <application>Archive Manager</application> sorts by name any files that have the same modification date.
     </para>
-  </sect2>
+  </section>
 
-  <sect2 id="engrampa-extra-info">
-    <title>To Display Additional Details</title>
+  <section xml:id="engrampa-extra-info"><info><title>To Display Additional Details</title></info>
+    
       <para>To open the <guilabel>Last Output</guilabel> dialog, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Last Output</guimenuitem></menuchoice>: 
             <itemizedlist>
               <listitem>
-                <para>If you tested the archive in the current &app; session, the <guilabel>Last Output</guilabel> dialog displays the results of the last test.
+                <para>If you tested the archive in the current <application>Archive Manager</application> session, the <guilabel>Last Output</guilabel> dialog displays the results of the last test.
                 </para>
               </listitem>
               <listitem>
-                <para>If you did not test the archive in the current &app; session, the <guilabel>Last Output</guilabel> dialog displays a list of all files in the archive, but does not indicate any status for the files. Instead, the <guilabel>Last Output</guilabel> dialog provides the compressed size of each file and the percentage of compression, and the date and time at which the file was last modified.
+                <para>If you did not test the archive in the current <application>Archive Manager</application> session, the <guilabel>Last Output</guilabel> dialog displays a list of all files in the archive, but does not indicate any status for the files. Instead, the <guilabel>Last Output</guilabel> dialog provides the compressed size of each file and the percentage of compression, and the date and time at which the file was last modified.
                 </para>
               </listitem>
             </itemizedlist>
     </para>
-  </sect2>
-</sect1>
+  </section>
+</section>
 
 <!-- ====== Using the File Manager Popup Menu to Manipulate an Archive ===== -->
 
-<sect1 id="engrampa-fmgr"> 
-    <title>Using the File Manager to Work with an Archive</title> 
+<section xml:id="engrampa-fmgr"><info><title>Using the File Manager to Work with an Archive</title></info> 
+     
     <para>
 	You can use the file manager to add files to an archive, or to extract files from an archive.</para>
 
 <!-- ======= Adding files Using File Manager Menu  ============= --> 
-    <sect2 id="engrampa-fmgr-add">
-      <title>To Add Files to an Archive by Using the File Manager</title>
+    <section xml:id="engrampa-fmgr-add"><info><title>To Add Files to an Archive by Using the File Manager</title></info>
+      
            <para>You can use the file manager to add files to an archive, in the following ways:
            <itemizedlist>
-             <listitem><para>Drag the files into a &app; window from a file manager window.</para>
+             <listitem><para>Drag the files into a <application>Archive Manager</application> window from a file manager window.</para>
              </listitem>
              <listitem><para>Use the file manager popup menu to add the files to the archive.</para>
              </listitem>
           </itemizedlist>
            </para>
       <para>To use the file manager popup menu to add files to an archive, perform the following steps:</para>
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem><para>Right-click on the files or folders in a file manager window. </para>
         </listitem>
-        <listitem><para>Choose <guimenuitem>Create Archive</guimenuitem> from the file manager popup menu to display the &app; <guilabel>Create Archive</guilabel> dialog.  </para>
+        <listitem><para>Choose <guimenuitem>Create Archive</guimenuitem> from the file manager popup menu to display the <application>Archive Manager</application> <guilabel>Create Archive</guilabel> dialog.  </para>
         </listitem>
         <listitem><para>Enter the archive name, without the file extension, in the <guilabel>Archive</guilabel> text box. </para>
         </listitem>
@@ -1345,37 +1325,37 @@
         </listitem>
         <listitem><para>Click <guilabel>Create</guilabel> to add the selected files to the root folder of the specified archive.
       </para>
-                 <note><para>To select any of the advanced add options, you must invoke &app; as described in <xref linkend="engrampa-to-start"/>.</para></note>
+                 <note><para>To select any of the advanced add options, you must invoke <application>Archive Manager</application> as described in <xref linkend="engrampa-to-start"/>.</para></note>
         </listitem>
       </orderedlist>
-    </sect2>
+    </section>
 
 <!-- ======= Extracting files Using File Manager Menu  ============= --> 
-  <sect2 id="engrampa-fmgr-extract">
-      <title>To Extract Files From an Archive by Using the File Manager</title>
+  <section xml:id="engrampa-fmgr-extract"><info><title>To Extract Files From an Archive by Using the File Manager</title></info>
+      
            <para>You can use the file manager to extract files from an archive, in the following ways:
            <itemizedlist>
-             <listitem><para>Drag the files from a &app; window into a file manager window.</para>
+             <listitem><para>Drag the files from a <application>Archive Manager</application> window into a file manager window.</para>
              </listitem>
              <listitem><para>Use the file manager popup menu to extract the files from the archive.</para>
              </listitem>
           </itemizedlist>
            </para>
       <para>To use the file manager popup menu to extract files from an archive, perform the following steps:</para>
-      <orderedlist>
+      <orderedlist inheritnum="ignore" continuation="restarts">
         <listitem><para>Right-click on the archive in a file manager window. </para>
         </listitem>
         <listitem><para>Choose <guimenuitem>Extract Here</guimenuitem> to extract all of the archive contents into the directory where the archive is located.</para>
         </listitem>
       </orderedlist>
-      <note><para>If the archive is encrypted, &app; will ask to enter the password before extracting the files.</para></note>
-    </sect2>
+      <note><para>If the archive is encrypted, <application>Archive Manager</application> will ask to enter the password before extracting the files.</para></note>
+    </section>
 
-</sect1>
+</section>
 
 <!-- ======= Create Archive Advanced Options  ============= --> 
-    <sect1 id="engrampa-create-options">
-      <title>Create Options</title>
+    <section xml:id="engrampa-create-options"><info><title>Create Options</title></info>
+      
       <para>When creating a new archive, or when converting an existing archive to another format, click on <guilabel>Other Options</guilabel> to specify the following advanced options: 
       </para>
       <variablelist>
@@ -1405,11 +1385,11 @@
 	  </listitem>
 	</varlistentry>
       </variablelist>
-    </sect1>
+    </section>
 
 <!-- ======= Add Advanced Options  ============= --> 
-    <sect1 id="engrampa-add-options">
-      <title>Add Options</title>
+    <section xml:id="engrampa-add-options"><info><title>Add Options</title></info>
+      
       <para>The <guilabel>Add Files</guilabel> and <guilabel>Add a Folder</guilabel> dialogs provide the following option: 
       </para>
       <variablelist>
@@ -1417,17 +1397,17 @@
 	<varlistentry>
 	  <term><guilabel>Add only if newer</guilabel></term>
 	  <listitem>
-            <para>Select this option to add the specified file to the archive only if the archive does not contain the specified file, or if the archive contains an older version of the specified file. &app; uses the modification date to determine which file is the most recent. If the version of the file in the archive is the most recent, &app; does not add the specified file to the archive.
+            <para>Select this option to add the specified file to the archive only if the archive does not contain the specified file, or if the archive contains an older version of the specified file. <application>Archive Manager</application> uses the modification date to determine which file is the most recent. If the version of the file in the archive is the most recent, <application>Archive Manager</application> does not add the specified file to the archive.
             </para>
-	    <para>If you do not select this option, &app; adds the file to the archive and overwrites the previous archive contents. 
+	    <para>If you do not select this option, <application>Archive Manager</application> adds the file to the archive and overwrites the previous archive contents. 
 	    </para>
-	    <tip>
-	      <title>Tip</title>
-	      <para>If you use &app; to create backups, the <guilabel>Add only if newer</guilabel> option is very useful. For example, the archive <filename>backup.tar.gz</filename> contains a week-old backup of your home folder. To update the archive to contain a current backup of your home folder, perform the following steps: 
-                    <orderedlist>
+	    <tip><info><title>Tip</title></info>
+	      
+	      <para>If you use <application>Archive Manager</application> to create backups, the <guilabel>Add only if newer</guilabel> option is very useful. For example, the archive <filename>backup.tar.gz</filename> contains a week-old backup of your home folder. To update the archive to contain a current backup of your home folder, perform the following steps: 
+                    <orderedlist inheritnum="ignore" continuation="restarts">
                       <listitem>
                         <para>
-                          Open the <filename>backup.tar.gz</filename> archive in &app;. 
+                          Open the <filename>backup.tar.gz</filename> archive in <application>Archive Manager</application>. 
                         </para>
                       </listitem>
                       <listitem>
@@ -1451,14 +1431,14 @@
                       </listitem>
                     </orderedlist>
                 </para>
-                <para>&app; automatically adds to the archive all files that you created during the last week, and updates all files that you modified during the last week. However, &app; does not remove from the archive the files that you deleted during the last week. The archive update operation is much faster than doing a full backup of your home folder. 
+                <para><application>Archive Manager</application> automatically adds to the archive all files that you created during the last week, and updates all files that you modified during the last week. However, <application>Archive Manager</application> does not remove from the archive the files that you deleted during the last week. The archive update operation is much faster than doing a full backup of your home folder. 
 	    </para>
 	  </tip>
 	</listitem>
       </varlistentry>
       </variablelist>
-      <sect2 id="engrampa-add-folder-options">
-      <title>Add to Folder Options</title>
+      <section xml:id="engrampa-add-folder-options"><info><title>Add to Folder Options</title></info>
+      
       <para>The following options are available in the <guilabel>Add a Folder</guilabel> dialog and allow to automatically select and add all files that satisfy certain criteria: 
       </para>
       <variablelist>
@@ -1497,7 +1477,7 @@
            The filename, not the subfolder name, must match the specified pattern. 
           </para>
           </note>
-	  <para>If you do not select this option, &app; adds the matching files from the current folder only.
+	  <para>If you do not select this option, <application>Archive Manager</application> adds the matching files from the current folder only.
 	  </para>
         </listitem>
       </varlistentry>
@@ -1507,7 +1487,7 @@
 	  <listitem>
             <para>Select this option to omit files from folders that are symbolic links. Symbolic links are pointers or shortcuts to other folders. 
             </para>
-	    <para>If you do not select this option, &app; adds the matching files from folders that are symbolic links.
+	    <para>If you do not select this option, <application>Archive Manager</application> adds the matching files from folders that are symbolic links.
 	    </para>
           </listitem>
 	</varlistentry>
@@ -1547,15 +1527,15 @@
           </listitem>
 	</varlistentry>
       </variablelist>
-    </sect2>
-  </sect1>
+    </section>
+  </section>
 
 <!-- ======= Extract Options  ============= --> 
-  <sect1 id="engrampa-extract-options">
-    <title>Extract Options</title>
+  <section xml:id="engrampa-extract-options"><info><title>Extract Options</title></info>
+    
       
     <para>
-	The <guilabel>Extract</guilabel> dialog provides the following options, which are saved when you quit &app;: 
+	The <guilabel>Extract</guilabel> dialog provides the following options, which are saved when you quit <application>Archive Manager</application>: 
       </para>
       <variablelist>
        <!-- ============= -->	
@@ -1608,11 +1588,11 @@
                 <para>For example, you specify <filename>/tmp</filename> in the <guilabel>Filename</guilabel> text box and choose to extract all files. The archive contains a subfolder called <filename>doc</filename>. 
                 <itemizedlist>
                   <listitem><para>
-                    If you select the <guilabel>Re-create folders</guilabel> option, &app; extracts the contents of the subfolder to <filename>/tmp/doc</filename>.
+                    If you select the <guilabel>Re-create folders</guilabel> option, <application>Archive Manager</application> extracts the contents of the subfolder to <filename>/tmp/doc</filename>.
                     </para>
                  </listitem>
                  <listitem><para>
-                   If you do not select the <guilabel>Re-create folders</guilabel> option, &app; does not create any subfolders. Instead, &app; extracts all files from the archive, including files from subfolders, to <filename>/tmp</filename>.
+                   If you do not select the <guilabel>Re-create folders</guilabel> option, <application>Archive Manager</application> does not create any subfolders. Instead, <application>Archive Manager</application> extracts all files from the archive, including files from subfolders, to <filename>/tmp</filename>.
                    </para>
                  </listitem>
                </itemizedlist>
@@ -1624,7 +1604,7 @@
 	           <listitem><para>
 	             Select this option to overwrite any files in the destination folder that have the same name as the specified files. </para>
 	             <para>
-                 If you do not select this option, &app; does not extract the specified file if an existing file with the same name already exists in the destination folder.</para>
+                 If you do not select this option, <application>Archive Manager</application> does not extract the specified file if an existing file with the same name already exists in the destination folder.</para>
 	           </listitem>
 	         </varlistentry>
              <!-- ============= -->	
@@ -1634,9 +1614,9 @@
 	             <para>This option is only effective while the <guilabel>Overwrite existing files</guilabel> option is selected.
 	             </para>
 	             <para>
-                   Select the <guilabel>Do not extract older files</guilabel> option to extract the specified file only if the destination folder does not contain the specified file, or if the destination folder contains an older version of the specified file. &app; uses the modification date to determine which file is the most recent. If the version of the file in the archive is older, &app; does not extract the specified file to the destination folder.</para>
+                   Select the <guilabel>Do not extract older files</guilabel> option to extract the specified file only if the destination folder does not contain the specified file, or if the destination folder contains an older version of the specified file. <application>Archive Manager</application> uses the modification date to determine which file is the most recent. If the version of the file in the archive is older, <application>Archive Manager</application> does not extract the specified file to the destination folder.</para>
 	             <para>
-                   If you do not select the <guilabel>Do not extract older files</guilabel> option while the <guilabel>Overwrite existing files</guilabel> option is selected, &app; extracts the specified file from the archive and overwrites the previous contents of the destination folder.
+                   If you do not select the <guilabel>Do not extract older files</guilabel> option while the <guilabel>Overwrite existing files</guilabel> option is selected, <application>Archive Manager</application> extracts the specified file from the archive and overwrites the previous contents of the destination folder.
 	             </para>
 	           </listitem>
 	         </varlistentry>
@@ -1644,7 +1624,5 @@
 	     </listitem>
 	   </varlistentry>
      </variablelist>	
-  </sect1>
-
-
+  </section>
 </article>

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -196,7 +196,7 @@
                 </revision>
          </revhistory>
 
-    <releaseinfo>This manual describes version 1.10 of Archive Manager.</releaseinfo> 
+    <releaseinfo>This manual describes version 1.22 of Archive Manager.</releaseinfo> 
   </info> 
 
   <indexterm zone="index"> 

--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -19,7 +19,7 @@
      </abstract>
 
     <copyright xml:lang="en">
-      <year>2015</year>
+      <year>2019</year>
       <holder>MATE Documentation Project</holder>
     </copyright>
     <copyright>

--- a/help/C/legal.xml
+++ b/help/C/legal.xml
@@ -1,12 +1,13 @@
-   <legalnotice id="legalnotice">
+<legalnotice xmlns="http://docbook.org/ns/docbook"
+             xmlns:xlink="http://www.w3.org/1999/xlink"
+             version="5.0" xml:id="legalnotice" xml:lang="en">
          <para>
            Permission is granted to copy, distribute and/or modify this
            document under the terms of the GNU Free Documentation
            License (GFDL), Version 1.1 or any later version published
            by the Free Software Foundation with no Invariant Sections,
            no Front-Cover Texts, and no Back-Cover Texts.  You can find
-           a copy of the GFDL at this <ulink type="help"
-           url="help:fdl">link</ulink> or in the file COPYING-DOCS
+           a copy of the GFDL at this <link xlink:href="https://www.gnu.org/licenses/fdl-1.1.html">link</link> or in the file COPYING-DOCS
            distributed with this manual.
           </para>
           <para> This manual is part of a collection of MATE manuals
@@ -72,5 +73,8 @@
                  </listitem>
            </orderedlist>
          </para>
+        <formalpara>
+            <title>Feedback</title>
+            <para>To report a bug or make a suggestion regarding the <application>Archive Manager</application> application or this manual, follow the directions in the <link xlink:href="help:mate-user-guide/feedback">MATE Feedback Page</link>.</para>
+        </formalpara>
    </legalnotice>
- 

--- a/help/engrampa.pot
+++ b/help/engrampa.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2018-10-04 16:11+0200\n"
+"POT-Creation-Date: 2019-02-07 12:02+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,655 +14,610 @@ msgctxt "_"
 msgid "translator-credits"
 msgstr ""
 
-#. (itstool) path: articleinfo/title
-#: C/index.docbook:29
-msgid "<application>Archive Manager</application> Manual"
+#. (itstool) path: info/title
+#: C/index.docbook:15
+msgid "Archive Manager Manual"
 msgstr ""
 
 #. (itstool) path: abstract/para
-#: C/index.docbook:31
+#: C/index.docbook:18
 msgid "Archive Manager, also known as Engrampa, allows you to create, view, modify, or unpack an archive."
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:33
+#. (itstool) path: info/copyright
+#: C/index.docbook:21
 msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:37
+#. (itstool) path: info/copyright
+#: C/index.docbook:25
 msgid "<year>2009</year> <holder>Paul Cutler</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:41
+#. (itstool) path: info/copyright
+#: C/index.docbook:29
 msgid "<year>2006</year> <year>2008</year> <holder>Paolo Bacchilega</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:46
+#. (itstool) path: info/copyright
+#: C/index.docbook:34
 msgid "<year>2003</year> <year>2004</year> <holder>Sun Microsystems</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:51
+#. (itstool) path: info/copyright
+#: C/index.docbook:39
 msgid "<year>2003</year> <holder>Paolo Bacchilega</holder>"
 msgstr ""
 
-#. (itstool) path: articleinfo/copyright
-#: C/index.docbook:55
+#. (itstool) path: info/copyright
+#: C/index.docbook:43
 msgid "<year>2002</year> <holder>Alexander Kirillov</holder>"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#: C/index.docbook:73
-#: C/index.docbook:131
+#: C/index.docbook:52
+#: C/index.docbook:119
 msgid "MATE Documentation Project"
 msgstr ""
 
 #. (itstool) path: publisher/publishername
 #. (itstool) path: revdescription/para
-#: C/index.docbook:76
-#: C/index.docbook:139
-#: C/index.docbook:148
-#: C/index.docbook:157
-#: C/index.docbook:166
-#: C/index.docbook:174
-#: C/index.docbook:182
-#: C/index.docbook:190
-#: C/index.docbook:198
-#: C/index.docbook:206
+#: C/index.docbook:55
+#: C/index.docbook:127
+#: C/index.docbook:136
+#: C/index.docbook:145
+#: C/index.docbook:154
+#: C/index.docbook:162
+#: C/index.docbook:170
+#: C/index.docbook:178
+#: C/index.docbook:186
+#: C/index.docbook:194
 msgid "GNOME Documentation Project"
 msgstr ""
 
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <ulink type=\"help\" url=\"help:fdl\">link</ulink> or in the file COPYING-DOCS distributed with this manual."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:12
-#: C/legal.xml:12
-msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:19
-#: C/legal.xml:19
-msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:35
-#: C/legal.xml:35
-msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
-msgstr ""
-
-#. (itstool) path: listitem/para
-#: C/index.docbook:55
-#: C/legal.xml:55
-msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:28
-#: C/legal.xml:28
-msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+#. (itstool) path: authorgroup/author
+#: C/index.docbook:64
+msgid "<orgname>MATE Documentation Project</orgname> <affiliation> <orgname>MATE Desktop</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:84
-msgid "<surname>MATE Documentation Team</surname> <affiliation> <orgname>Mate desktop</orgname> </affiliation>"
+#: C/index.docbook:70
+msgid "<personname> <firstname>Sun </firstname> <surname>GNOME Documentation Team</surname> </personname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:90
-msgid "<firstname>Sun </firstname> <surname>GNOME Documentation Team</surname> <affiliation> <orgname>Sun Microsystems</orgname> </affiliation>"
+#: C/index.docbook:79
+msgid "<personname> <firstname>Paolo</firstname> <surname>Bacchilega</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:97
-msgid "<firstname>Paolo</firstname> <surname>Bacchilega</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation>"
+#: C/index.docbook:88
+msgid "<personname> <firstname>Alexander</firstname> <surname>Kirillov</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>kirillov@math.sunysb.edu</email>"
 msgstr ""
 
 #. (itstool) path: authorgroup/author
-#: C/index.docbook:104
-msgid "<firstname>Alexander</firstname> <surname>Kirillov</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> <address> <email>kirillov@math.sunysb.edu</email> </address> </affiliation>"
-msgstr ""
-
-#. (itstool) path: authorgroup/author
-#: C/index.docbook:112
-msgid "<firstname>Paul</firstname> <surname>Cutler</surname> <affiliation> <orgname>GNOME Documentation Project</orgname> <address><email>pcutler@foresightlinux.org</email></address> </affiliation>"
+#: C/index.docbook:98
+msgid "<personname> <firstname>Paul</firstname> <surname>Cutler</surname> </personname> <affiliation> <orgname>GNOME Documentation Project</orgname> </affiliation> <email>pcutler@foresightlinux.org</email>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:130
+#: C/index.docbook:118
 msgid "Wolfgang Ulbrich"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:126
-msgid "<revnumber>Archive Manager Manual V1.10.0</revnumber> <date>July 2015</date> <_:revdescription-1/>"
+#: C/index.docbook:114
+msgid "<revnumber>1.10.0</revnumber> <date>July 2015</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:138
+#: C/index.docbook:126
 msgid "Paul Cutler"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:134
-msgid "<revnumber>Archive Manager Manual V2.26.0</revnumber> <date>March 2009</date> <_:revdescription-1/>"
+#: C/index.docbook:122
+msgid "<revnumber>2.26.0</revnumber> <date>March 2009</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:147
-#: C/index.docbook:156
-#: C/index.docbook:197
+#: C/index.docbook:135
+#: C/index.docbook:144
+#: C/index.docbook:185
 msgid "Paolo Bacchilega"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:143
-msgid "<revnumber>Archive Manager Manual V2.24.0</revnumber> <date>July 2008</date> <_:revdescription-1/>"
+#: C/index.docbook:131
+msgid "<revnumber>2.24.0</revnumber> <date>July 2008</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:152
-msgid "<revnumber>Archive Manager Manual V2.6</revnumber> <date>April 2006</date> <_:revdescription-1/>"
+#: C/index.docbook:140
+msgid "<revnumber>2.6</revnumber> <date>April 2006</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:165
-#: C/index.docbook:173
-#: C/index.docbook:181
-#: C/index.docbook:189
+#: C/index.docbook:153
+#: C/index.docbook:161
+#: C/index.docbook:169
+#: C/index.docbook:177
 msgid "Sun GNOME Documentation Team"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:161
-msgid "<revnumber>Engrampa Manual V2.5</revnumber> <date>March 2004</date> <_:revdescription-1/>"
+#: C/index.docbook:149
+msgid "<revnumber>2.5</revnumber> <date>March 2004</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:169
-msgid "<revnumber>Engrampa Manual V2.4</revnumber> <date>February 2004</date> <_:revdescription-1/>"
+#: C/index.docbook:157
+msgid "<revnumber>2.4</revnumber> <date>February 2004</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:177
-msgid "<revnumber>Engrampa Manual V2.3</revnumber> <date>August 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:165
+msgid "<revnumber>2.3</revnumber> <date>August 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:185
-msgid "<revnumber>Engrampa Manual V2.2</revnumber> <date>June 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:173
+msgid "<revnumber>2.2</revnumber> <date>June 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:193
-msgid "<revnumber>Engrampa Manual V2.1</revnumber> <date>January 2003</date> <_:revdescription-1/>"
+#: C/index.docbook:181
+msgid "<revnumber>2.1</revnumber> <date>January 2003</date> <_:revdescription-1/>"
 msgstr ""
 
 #. (itstool) path: revdescription/para
-#: C/index.docbook:205
+#: C/index.docbook:193
 msgid "Alexander Kirillov"
 msgstr ""
 
 #. (itstool) path: revhistory/revision
-#: C/index.docbook:201
-msgid "<revnumber>Engrampa Manual V2.0</revnumber> <date>June 2002</date> <_:revdescription-1/>"
+#: C/index.docbook:189
+msgid "<revnumber>2.0</revnumber> <date>June 2002</date> <_:revdescription-1/>"
 msgstr ""
 
-#. (itstool) path: articleinfo/releaseinfo
-#: C/index.docbook:211
+#. (itstool) path: info/releaseinfo
+#: C/index.docbook:199
 msgid "This manual describes version 1.10 of Archive Manager."
 msgstr ""
 
-#. (itstool) path: legalnotice/title
-#: C/index.docbook:214
-msgid "Feedback"
-msgstr ""
-
-#. (itstool) path: legalnotice/para
-#: C/index.docbook:215
-msgid "To report a bug or make a suggestion regarding the <application>Archive Manager</application> application or this manual, follow the directions in the <ulink url=\"help:mate-user-guide/feedback\" type=\"help\">MATE Feedback Page</ulink>."
-msgstr ""
-
 #. (itstool) path: article/indexterm
-#: C/index.docbook:221
+#: C/index.docbook:202
 msgid "<primary>Engrampa</primary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:224
+#: C/index.docbook:205
 msgid "<primary>engrampa</primary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:227
+#: C/index.docbook:208
 msgid "<primary>Archiving</primary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:230
+#: C/index.docbook:211
 msgid "<primary>Archives</primary> <secondary>Adding files to</secondary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:234
+#: C/index.docbook:215
 msgid "<primary>Archives</primary> <secondary>Deleting files from</secondary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:238
+#: C/index.docbook:219
 msgid "<primary>Archives</primary> <secondary>Opening</secondary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:242
+#: C/index.docbook:223
 msgid "<primary>Archives</primary> <secondary>Viewing</secondary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:246
+#: C/index.docbook:227
 msgid "<primary>Archives</primary> <secondary>Extracting</secondary>"
 msgstr ""
 
 #. (itstool) path: article/indexterm
-#: C/index.docbook:250
+#: C/index.docbook:231
 msgid "<primary>Archives</primary> <secondary>Creating</secondary>"
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:260
+#. (itstool) path: info/title
+#: C/index.docbook:240
 msgid "Introduction"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:261
+#. (itstool) path: section/para
+#: C/index.docbook:242
 msgid "You can use the <application>Archive Manager</application> application to create, view, modify, or unpack an archive. An archive is a file that acts as a container for other files. An archive can contain many files, folders, and subfolders, usually in compressed form."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:263
+#. (itstool) path: section/para
+#: C/index.docbook:244
 msgid "<application>Archive Manager</application> provides only a graphical interface, and relies on command-line utilities such as <command>tar</command>, <command>gzip</command>, and <command>bzip2</command> for archive operations."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:266
+#. (itstool) path: section/para
+#: C/index.docbook:247
 msgid "If you have the appropriate command-line tools installed on your system, <application>Archive Manager</application> supports the archive formats listed in the following table."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:275
+#: C/index.docbook:256
 msgid "Format"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:277
+#: C/index.docbook:258
 msgid "Filename Extension"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:282
+#: C/index.docbook:263
 msgid "7-zip archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:283
+#: C/index.docbook:264
 msgid "<filename>.7z</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:286
+#: C/index.docbook:267
 msgid "ACE archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:287
+#: C/index.docbook:268
 msgid "<filename>.ace</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:290
+#: C/index.docbook:271
 msgid "Alzip archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:291
+#: C/index.docbook:272
 msgid "<filename>.alz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:294
+#: C/index.docbook:275
 msgid "AR archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:295
+#: C/index.docbook:276
 msgid "<filename>.ar</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:298
+#: C/index.docbook:279
 msgid "ARJ archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:299
+#: C/index.docbook:280
 msgid "<filename>.arj</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:302
+#: C/index.docbook:283
 msgid "Microsoft Cabinet archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:303
+#: C/index.docbook:284
 msgid "<filename>.cab</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:306
+#: C/index.docbook:287
 msgid "CPIO archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:307
+#: C/index.docbook:288
 msgid "<filename>.cpio</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:310
+#: C/index.docbook:291
 msgid "Debian package"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:311
+#: C/index.docbook:292
 msgid "<filename>.deb</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:314
+#: C/index.docbook:295
 msgid "raw CD image"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:315
+#: C/index.docbook:296
 msgid "<filename>.iso</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:318
+#: C/index.docbook:299
 msgid "Java archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:319
+#: C/index.docbook:300
 msgid "<filename>.jar</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:322
+#: C/index.docbook:303
 msgid "Enterprise Application aRchive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:323
+#: C/index.docbook:304
 msgid "<filename>.ear</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:326
+#: C/index.docbook:307
 msgid "Web Application Resource or Web application ARchive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:327
+#: C/index.docbook:308
 msgid "<filename>.war</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:330
+#: C/index.docbook:311
 msgid "LHA archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:331
+#: C/index.docbook:312
 msgid "<filename>.lha</filename>, <filename>.lzh</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:334
+#: C/index.docbook:315
 msgid "Roshal ARchive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:335
+#: C/index.docbook:316
 msgid "<filename>.rar</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:338
+#: C/index.docbook:319
 msgid "Comic Book (Rar-compressed)"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:339
+#: C/index.docbook:320
 msgid "<filename>.cbr</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:342
+#: C/index.docbook:323
 msgid "RPM package"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:343
+#: C/index.docbook:324
 msgid "<filename>.rpm</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:346
+#: C/index.docbook:327
 msgid "Tar archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:347
+#: C/index.docbook:328
 msgid "<filename>.tar</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:350
+#: C/index.docbook:331
 msgid "Tar archive compressed with <command>bzip</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:351
+#: C/index.docbook:332
 msgid "<filename>.tar.bz</filename> or <filename>.tbz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:354
+#: C/index.docbook:335
 msgid "Tar archive compressed with <command>bzip2</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:355
+#: C/index.docbook:336
 msgid "<filename>.tar.bz2</filename> or <filename>.tbz2</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:358
+#: C/index.docbook:339
 msgid "Tar archive compressed with <command>gzip</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:359
+#: C/index.docbook:340
 msgid "<filename>.tar.gz</filename> or <filename>.tgz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:362
+#: C/index.docbook:343
 msgid "Tar archive compressed with <command>lzip</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:363
+#: C/index.docbook:344
 msgid "<filename>.tar.lz</filename> or <filename>.tlz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:366
+#: C/index.docbook:347
 msgid "Tar archive compressed with <command>lzop</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:367
+#: C/index.docbook:348
 msgid "<filename>.tar.lzo</filename> or <filename>.tzo</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:370
+#: C/index.docbook:351
 msgid "Tar archive compressed with <command>compress</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:371
+#: C/index.docbook:352
 msgid "<filename>.tar.Z</filename> or <filename>.taz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:374
+#: C/index.docbook:355
 msgid "Tar archive compressed with <command>7zip</command>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:375
+#: C/index.docbook:356
 msgid "<filename>.tar.7z</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:378
+#: C/index.docbook:359
 msgid "StuffIt archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:379
+#: C/index.docbook:360
 msgid "<filename>.bin</filename> or <filename>.sit</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:382
+#: C/index.docbook:363
 msgid "Zip archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:383
+#: C/index.docbook:364
 msgid "<filename>.zip</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:386
+#: C/index.docbook:367
 msgid "Comic Book (Zip-compressed)"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:387
+#: C/index.docbook:368
 msgid "<filename>.cbz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:390
+#: C/index.docbook:371
 msgid "Zoo archive"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:391
+#: C/index.docbook:372
 msgid "<filename>.zoo</filename>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:396
+#. (itstool) path: section/para
+#: C/index.docbook:377
 msgid "The most common archive format on Linux and Unix-like systems is the tar archive compressed with <command>gzip</command> or <command>bzip2</command>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:397
+#. (itstool) path: section/para
+#: C/index.docbook:378
 msgid "The most common archive format on Microsoft Windows systems is the archive created with <application>PKZIP</application> or <application>WinZip</application>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:399
+#. (itstool) path: info/title
+#: C/index.docbook:379
 msgid "Compressed Non-Archive Files"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:400
+#. (itstool) path: section/para
+#: C/index.docbook:381
 msgid "A compressed non-archive file is a file that is created when you use <command>bzip2</command>, <command>gzip</command>, <command>lzip</command>, <command>lzop</command>, <command>compress</command> or <command>rzip</command> to compress a non-archive file. For example, <filename>file.txt.gz</filename> is created when you use <command>gzip</command> to compress <filename>file.txt</filename>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:401
+#. (itstool) path: section/para
+#: C/index.docbook:382
 msgid "You can use <application>Archive Manager</application> to create, open and extract a compressed non-archive file."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:407
+#. (itstool) path: info/title
+#: C/index.docbook:387
 msgid "Getting Started"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:408
+#. (itstool) path: section/para
+#: C/index.docbook:389
 msgid "This section provides information on how to start <application>Archive Manager</application>, and describes the <application>Archive Manager</application> user interface."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:413
+#. (itstool) path: info/title
+#: C/index.docbook:393
 msgid "To Start <application>Archive Manager</application>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:414
+#. (itstool) path: section/para
+#: C/index.docbook:395
 msgid "You can start <application>Archive Manager</application> in the following ways:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:417
+#: C/index.docbook:398
 msgid "<guimenu>Applications</guimenu> menu"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:419
+#: C/index.docbook:400
 msgid "Choose <menuchoice><guisubmenu>Accessories</guisubmenu><guimenuitem>Archive Manager</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:423
+#: C/index.docbook:404
 msgid "Command line"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:425
+#: C/index.docbook:406
 msgid "Execute the following command: <command>engrampa</command>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:432
+#. (itstool) path: info/title
+#: C/index.docbook:412
 msgid "When You Start <application>Archive Manager</application>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:433
+#. (itstool) path: section/para
+#: C/index.docbook:414
 msgid "When you start <application>Archive Manager</application>, the following window is displayed:"
 msgstr ""
 
-#. (itstool) path: figure/title
-#: C/index.docbook:436
+#. (itstool) path: info/title
+#: C/index.docbook:416
 msgid "<application>Archive Manager</application> Window"
 msgstr ""
 
@@ -671,1127 +626,1127 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:440
+#: C/index.docbook:421
 msgctxt "_"
 msgid "external ref='figures/engrampa_main_window.png' md5='1ffe6686c623c5a279a1ad13fb8eb488'"
 msgstr ""
 
 #. (itstool) path: screenshot/mediaobject
-#: C/index.docbook:438
+#: C/index.docbook:419
 msgid "<imageobject> <imagedata fileref=\"figures/engrampa_main_window.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows Engrampa main window.</phrase> </textobject>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:448
+#. (itstool) path: section/para
+#: C/index.docbook:429
 msgid "The <application>Archive Manager</application> window contains the following elements:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
 #. (itstool) path: entry/para
-#: C/index.docbook:450
-#: C/index.docbook:522
+#: C/index.docbook:431
+#: C/index.docbook:502
 msgid "Menubar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:452
+#: C/index.docbook:433
 msgid "The menus on the menubar contain all of the commands that you need to work with archives in <application>Archive Manager</application>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
 #. (itstool) path: entry/para
-#: C/index.docbook:455
-#: C/index.docbook:528
+#: C/index.docbook:436
+#: C/index.docbook:508
 msgid "Toolbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:457
+#: C/index.docbook:438
 msgid "The toolbar contains a subset of the commands that you can access from the menubar. <application>Archive Manager</application> displays the toolbar by default. To hide the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice>. To show the toolbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Toolbar</guimenuitem></menuchoice> again."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:460
+#: C/index.docbook:441
 msgid "Folderbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:462
+#: C/index.docbook:443
 msgid "The folderbar enables you to navigate among folders within an archive. <application>Archive Manager</application> displays the folderbar only in folder view. See <xref linkend=\"engrampa-view-type-folder\"/> for more information."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:465
+#: C/index.docbook:446
 msgid "Display area"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:467
+#: C/index.docbook:448
 msgid "The display area displays the contents of the archive."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:470
+#: C/index.docbook:451
 msgid "Statusbar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:472
+#: C/index.docbook:453
 msgid "The statusbar displays information about current <application>Archive Manager</application> activity and contextual information about the archive contents. <application>Archive Manager</application> displays the statusbar by default. To hide the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice>. To show the statusbar, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Statusbar</guimenuitem></menuchoice> again."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:476
+#. (itstool) path: section/para
+#: C/index.docbook:457
 msgid "When you right-click in the <application>Archive Manager</application> window, the application displays a popup menu. The popup menu contains the most common contextual archive commands."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:479
+#. (itstool) path: info/title
+#: C/index.docbook:459
 msgid "Browsing the Filesystem"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:480
-msgid "Several <application>Archive Manager</application> dialogs (<guilabel>New</guilabel>, <guilabel>Open</guilabel>, <guilabel>Extract</guilabel>,...) enable you to browse files and folders on your computer. Refer to the <ulink type=\"help\" url=\"help:mate-user-guide/filechooser-open\">Desktop User Guide</ulink> to learn more about using the file browsing dialogs."
+#. (itstool) path: section/para
+#: C/index.docbook:461
+msgid "Several <application>Archive Manager</application> dialogs (<guilabel>New</guilabel>, <guilabel>Open</guilabel>, <guilabel>Extract</guilabel>,...) enable you to browse files and folders on your computer. Refer to the <link xlink:href=\"help:mate-user-guide/filechooser-open\">Desktop User Guide</link> to learn more about using the file browsing dialogs."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:484
-msgid "You can also refer to the <ulink type=\"help\" url=\"help:mate-user-guide/caja-bookmarks\">Bookmarks section</ulink> of the Desktop User Guide to learn how you can use the <guilabel>Places</guilabel> pane to access your favorite locations."
+#. (itstool) path: section/para
+#: C/index.docbook:464
+msgid "You can also refer to the <link xlink:href=\"help:mate-user-guide/caja-bookmarks\">Bookmarks section</link> of the Desktop User Guide to learn how you can use the <guilabel>Places</guilabel> pane to access your favorite locations."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:496
+#. (itstool) path: info/title
+#: C/index.docbook:475
 msgid "Working With Archives"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:497
+#. (itstool) path: section/para
+#: C/index.docbook:477
 msgid "When you use <application>Archive Manager</application> to work with an archive, all changes are saved to disk immediately. For example, if you delete a file from an archive, <application>Archive Manager</application> deletes the file as soon as you click <guibutton>OK</guibutton>. This behavior is different to that of most applications, which save the changes to disk only when you quit the application or select <guimenuitem>Save</guimenuitem> in the menu."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:499
+#. (itstool) path: section/para
+#: C/index.docbook:479
 msgid "If an archive is very large, or you have a slow system, some archive actions can take significant time. To abort the current action, press <keycap>Esc</keycap>. Alternatively, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Stop</guimenuitem></menuchoice>, or click <guibutton>Stop</guibutton> in the toolbar."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:511
+#: C/index.docbook:491
 msgid "UI Component"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:513
+#: C/index.docbook:493
 msgid "Action"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:518
+#: C/index.docbook:498
 msgid "Window"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:519
+#: C/index.docbook:499
 msgid "Drag an archive into the <application>Archive Manager</application> window from another application such as a file manager."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:523
+#: C/index.docbook:503
 msgid "Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Open</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:524
+#: C/index.docbook:504
 msgid "If you have recently opened the archive, it will be listed directly in the <menuchoice><guimenu>Archive</guimenu></menuchoice> menu."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:529
+#: C/index.docbook:509
 msgid "Click on the <guibutton>Open</guibutton> toolbar button."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:530
+#: C/index.docbook:510
 msgid "If you have recently opened the archive, click on the down arrow near the <guibutton>Open</guibutton> toolbar button."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:533
+#: C/index.docbook:513
 msgid "Right-click popup menu"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:534
+#: C/index.docbook:514
 msgid "Right-click on the archive, then choose <guilabel>Open</guilabel> from the popup menu."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:537
+#: C/index.docbook:517
 msgid "Shortcut keys"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:538
+#: C/index.docbook:518
 msgid "Press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:502
+#. (itstool) path: section/para
+#: C/index.docbook:482
 msgid "In <application>Archive Manager</application>, you can perform the same action in several ways. For example, you can open an archive in the following ways: <_:informaltable-1/>"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:544
+#. (itstool) path: section/para
+#: C/index.docbook:524
 msgid "This manual documents functionality from the menubar."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:549
+#. (itstool) path: info/title
+#: C/index.docbook:528
 msgid "Filename Patterns"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:550
+#. (itstool) path: section/para
+#: C/index.docbook:530
 msgid "<application>Archive Manager</application> enables you to add, extract, or delete several files at once. To apply an action to all files that match a certain pattern, enter the pattern in the text box. The pattern can include standard wildcard symbols such as <keycap>*</keycap> to match any string, and <keycap>?</keycap> to match any single symbol. You can enter several patterns separated by semicolons. <application>Archive Manager</application> applies the action to all files that match at least one of the patterns. The examples in the following table show how to use filename patterns to select files."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:559
+#: C/index.docbook:539
 msgid "Pattern"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:561
+#: C/index.docbook:541
 msgid "Files Matched"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:566
+#: C/index.docbook:546
 msgid "<filename>*</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:567
+#: C/index.docbook:547
 msgid "All files"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:570
+#: C/index.docbook:550
 msgid "<filename>*.tar*</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:571
+#: C/index.docbook:551
 msgid "All files with extension <filename>tar</filename>, including those in which the <filename>tar</filename> extension is followed by any sequence of symbols, such as <filename>filename.tar.gz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:574
+#: C/index.docbook:554
 msgid "<filename>*.jpg; *.jpeg</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:575
+#: C/index.docbook:555
 msgid "All files with extension <filename>jpg</filename> and all files with extension <filename>jpeg</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:578
+#: C/index.docbook:558
 msgid "<filename>file?.gz</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:579
+#: C/index.docbook:559
 msgid "All files with extension <filename>gz</filename> that have the name \"file\" followed by any single character, e.g. <filename>file2.gz</filename>, <filename>filex.gz</filename>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:589
+#. (itstool) path: info/title
+#: C/index.docbook:568
 msgid "To Open an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:594
+#: C/index.docbook:574
 msgid "Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Open</guimenuitem></menuchoice> to display the <guilabel>Open</guilabel> dialog. Alternatively press <keycombo><keycap>Ctrl</keycap><keycap>O</keycap></keycombo>, or click <guibutton>Open</guibutton> in the toolbar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:597
+#: C/index.docbook:577
 msgid "Select the archive that you want to open."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:600
+#: C/index.docbook:580
 msgid "Click <guibutton>Open</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:590
+#. (itstool) path: section/para
+#: C/index.docbook:570
 msgid "To open an archive, perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:607
+#: C/index.docbook:587
 msgid "The archive name in the window titlebar"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:610
+#: C/index.docbook:590
 msgid "The archive contents in the display area"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:613
+#: C/index.docbook:593
 msgid "The number files and folders (objects) in the current location, and their size when uncompressed, in the statusbar"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:604
+#. (itstool) path: section/para
+#: C/index.docbook:584
 msgid "<application>Archive Manager</application> automatically determines the archive type, and displays: <_:itemizedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:617
+#. (itstool) path: section/para
+#: C/index.docbook:597
 msgid "To open another archive, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Open</guimenuitem></menuchoice> again. <application>Archive Manager</application> opens each archive in a new window. You can't open another archive in the same window."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:620
+#. (itstool) path: section/para
+#: C/index.docbook:600
 msgid "If you try to open an archive that was created in a format that <application>Archive Manager</application> does not recognize, the application displays an error message. See <xref linkend=\"engrampa-intro\"/> for a list of supported formats."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:627
+#. (itstool) path: info/title
+#: C/index.docbook:606
 msgid "To Select Files in an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:628
+#. (itstool) path: section/para
+#: C/index.docbook:608
 msgid "To select all files in an archive, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Select All</guimenuitem></menuchoice> or press <keycombo><keycap>Ctrl</keycap><keycap>A</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:630
+#. (itstool) path: section/para
+#: C/index.docbook:610
 msgid "To deselect all files in an archive, choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Deselect All</guimenuitem></menuchoice> or press <keycombo><keycap>Shift</keycap><keycap>Ctrl</keycap><keycap>A</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:637
+#. (itstool) path: info/title
+#: C/index.docbook:616
 msgid "To Extract Files From an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:641
+#: C/index.docbook:621
 msgid "Select the files that you want to extract. To select more files, press-and-hold <keycap>Ctrl</keycap> and click on the files you want to select."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:644
+#: C/index.docbook:624
 msgid "Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Extract</guimenuitem></menuchoice> to display the <guilabel>Extract</guilabel> dialog. Alternatively click <guibutton>Extract</guibutton> in the toolbar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:647
+#: C/index.docbook:627
 msgid "Select the folder where <application>Archive Manager</application> extracts the files."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:650
+#: C/index.docbook:630
 msgid "Select the required extract options. For more information about the extract options, see <xref linkend=\"engrampa-extract-options\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:653
+#: C/index.docbook:633
 msgid "Click <guibutton>Extract</guibutton>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:656
-#: C/index.docbook:814
+#: C/index.docbook:636
+#: C/index.docbook:794
 msgid "If all of the files in the archive are protected by a password, and you have not specified it, <application>Archive Manager</application> asks you to enter the password."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:659
+#: C/index.docbook:639
 msgid "If some but not all of the files in the archive are protected by a password, and you have not specified the password, <application>Archive Manager</application> does not ask for a password. However, <application>Archive Manager</application> extracts only the unprotected files."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:662
-#: C/index.docbook:820
+#: C/index.docbook:642
+#: C/index.docbook:800
 msgid "For more information about passwords, see <xref linkend=\"engrampa-encrypt-files\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:638
+#. (itstool) path: section/para
+#: C/index.docbook:618
 msgid "To extract files from an open archive, perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:669
+#. (itstool) path: section/para
+#: C/index.docbook:649
 msgid "<application>Archive Manager</application> also provides ways of extracting files from an archive in a file manager window, without opening a <application>Archive Manager</application> window. See <xref linkend=\"engrampa-fmgr\"/> for more information."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:670
+#. (itstool) path: section/para
+#: C/index.docbook:650
 msgid "The Extract operation extracts a <emphasis>copy</emphasis> of the specified files from the archive. The extracted files have the same permissions and modification date as the original files that were added to the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:673
+#. (itstool) path: section/para
+#: C/index.docbook:653
 msgid "The Extract operation does not change the contents of the archive. For information on how to delete files from an archive, see <xref linkend=\"engrampa-delete-files\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:680
+#. (itstool) path: info/title
+#: C/index.docbook:659
 msgid "To Close an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:681
+#. (itstool) path: section/para
+#: C/index.docbook:661
 msgid "To close the current archive and the current <application>Archive Manager</application> window, choose <menuchoice> <guimenu>Archive</guimenu> <guimenuitem>Close</guimenuitem> </menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>W</keycap></keycombo>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:684
+#: C/index.docbook:664
 msgid "There is no way to close the current archive but not the <application>Archive Manager</application> window."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:693
+#. (itstool) path: info/title
+#: C/index.docbook:672
 msgid "Creating Archives"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:694
+#. (itstool) path: section/para
+#: C/index.docbook:674
 msgid "In addition to opening existing archives, you can also create new archives with <application>Archive Manager</application>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:697
+#. (itstool) path: info/title
+#: C/index.docbook:676
 msgid "To Create an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:702
+#: C/index.docbook:682
 msgid "Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>New</guimenuitem></menuchoice> to display the <guilabel>New</guilabel> dialog. Alternatively press <keycombo><keycap>Ctrl</keycap><keycap>N</keycap></keycombo>, or click <guibutton>New</guibutton> in the toolbar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:706
+#: C/index.docbook:686
 msgid "Specify the folder where <application>Archive Manager</application> places the new archive clicking on the entry in the <guilabel>Save in folder</guilabel> drop-down list. If the folder is not present in list, click on <guilabel>Browse for other folders</guilabel>, and select the folder. Alternatively, enter the path in the <guilabel>Name</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:710
+#: C/index.docbook:690
 msgid "Enter the name of the new archive, including the file extension, in the <guilabel>Name</guilabel> text box. Alternatively you can specify the archive name without extension, and then select the archive type from the <guilabel>Archive type</guilabel> drop-down menu, this way the extension will be added automatically."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:713
-#: C/index.docbook:807
-#: C/index.docbook:1343
+#: C/index.docbook:693
+#: C/index.docbook:787
+#: C/index.docbook:1323
 msgid "Select the required create options clicking on <guilabel>Other Options</guilabel>. For more information about the create options, see <xref linkend=\"engrampa-create-options\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:717
+#: C/index.docbook:697
 msgid "Click <guibutton>New</guibutton>. <application>Archive Manager</application> creates an empty archive, but does not yet write the archive to disk."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:723
+#: C/index.docbook:703
 msgid "<application>Archive Manager</application> writes a new archive to disk only when the archive contains at least one file. If you create a new archive and quit <application>Archive Manager</application> before you add any files to the archive, <application>Archive Manager</application> deletes the archive."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:721
+#: C/index.docbook:701
 msgid "Add files to the new archive as described in <xref linkend=\"engrampa-add-files\"/>. <_:note-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:698
+#. (itstool) path: section/para
+#: C/index.docbook:678
 msgid "To create an archive, perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:734
+#. (itstool) path: info/title
+#: C/index.docbook:713
 msgid "To Add Files to an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:739
-#: C/index.docbook:767
+#: C/index.docbook:719
+#: C/index.docbook:747
 msgid "Decide where in the archive you want to add the files, then open that location in the archive."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:742
+#: C/index.docbook:722
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Add Files</guimenuitem></menuchoice> to display the <guilabel>Add Files</guilabel> dialog, or click <guibutton>Add Files</guibutton> in the toolbar."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:745
+#: C/index.docbook:725
 msgid "Select the files that you want to add. To select more files press-and-hold <keycap>Ctrl</keycap> and click the files."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:748
+#: C/index.docbook:728
 msgid "Click <guibutton>Add</guibutton>. <application>Archive Manager</application> adds the files to the current folder in the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:735
+#. (itstool) path: section/para
+#: C/index.docbook:715
 msgid "To add files to an archive, perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:753
+#. (itstool) path: section/para
+#: C/index.docbook:733
 msgid "You cannot add folders to the archive with the <guilabel>Add Files</guilabel> dialog. To add a folder see <xref linkend=\"engrampa-add-folder\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:754
+#. (itstool) path: section/para
+#: C/index.docbook:734
 msgid "The <guilabel>Add Files</guilabel> dialog provides the <guilabel>Add only if newer</guilabel> option, see <xref linkend=\"engrampa-add-options\"/> for more information on this option."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:755
+#. (itstool) path: section/para
+#: C/index.docbook:735
 msgid "You can also add files to an archive in a file manager window, without opening an <application>Archive Manager</application> window. See <xref linkend=\"engrampa-fmgr\"/> for more information."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:756
+#. (itstool) path: section/para
+#: C/index.docbook:736
 msgid "The Add operation adds a <emphasis>copy</emphasis> of the specified files or folders to the archive. <application>Archive Manager</application> does not remove the original files, which remain unchanged in the file system. The copies that are added to the archive have the same permissions and modification date as the original files."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:762
+#. (itstool) path: info/title
+#: C/index.docbook:741
 msgid "To Add a Folder to an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:770
+#: C/index.docbook:750
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Add a Folder</guimenuitem></menuchoice> to display the <guilabel>Add a Folder</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:773
+#: C/index.docbook:753
 msgid "Select the folder that you want to add."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:776
+#: C/index.docbook:756
 msgid "Click <guibutton>Add</guibutton>. <application>Archive Manager</application> adds the folder to the current folder in the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:763
+#. (itstool) path: section/para
+#: C/index.docbook:743
 msgid "To add a folder to an archive, perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:781
+#. (itstool) path: section/para
+#: C/index.docbook:761
 msgid "The <guilabel>Add a Folder</guilabel> dialog provides several advanced options. See <xref linkend=\"engrampa-add-options\"/> for more information."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:786
+#. (itstool) path: info/title
+#: C/index.docbook:765
 msgid "To Convert an Archive to Another Format"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:787
+#. (itstool) path: section/para
+#: C/index.docbook:767
 msgid "To convert an archive to another format and save as a new file, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:791
+#: C/index.docbook:771
 msgid "Open the archive that you want to convert."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:795
+#: C/index.docbook:775
 msgid "Choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Save As</guimenuitem></menuchoice> to display the <guilabel>Save</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:799
+#: C/index.docbook:779
 msgid "Enter the new archive name in the <guilabel>Name</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:803
+#: C/index.docbook:783
 msgid "Select the new format from the <guilabel>Archive type</guilabel> drop-down list. Alternatively, enter the filename extension in the <guilabel>Name</guilabel> text box, and select <guilabel>Automatic</guilabel> from the <guilabel>Archive type</guilabel> drop-down list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:811
+#: C/index.docbook:791
 msgid "Click <guibutton>Save</guibutton>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:817
+#: C/index.docbook:797
 msgid "If some but not all of the files in the archive are protected by a password, and you have not specified the password, <application>Archive Manager</application> does not ask for a password. However, <application>Archive Manager</application> copies only the unprotected files to the new archive."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:831
+#. (itstool) path: info/title
+#: C/index.docbook:810
 msgid "Modifying the Contents of an Archive"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:832
+#. (itstool) path: section/para
+#: C/index.docbook:812
 msgid "You can modify the contents of an archive in several ways."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:838
+#. (itstool) path: info/title
+#: C/index.docbook:817
 msgid "To Encrypt Files in an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:839
+#. (itstool) path: section/para
+#: C/index.docbook:819
 msgid "For security, you might want to encrypt the files that you add to an archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:840
+#. (itstool) path: section/para
+#: C/index.docbook:820
 msgid "If the archive format supports encryption, you can specify a password to encrypt the files that you add to the archive."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:842
+#: C/index.docbook:822
 msgid "Currently, only 7-Zip, ZIP, RAR and ARJ archives support encryption."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:844
+#. (itstool) path: section/para
+#: C/index.docbook:824
 msgid "To specify a password for file encryption, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:846
+#: C/index.docbook:826
 msgid "Choose <menuchoice><guimenu>Edit</guimenu> <guimenuitem>Password</guimenuitem></menuchoice> to display the <guilabel>Password</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:847
+#: C/index.docbook:827
 msgid "Enter the password in the <guilabel>Password</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:848
-#: C/index.docbook:962
+#: C/index.docbook:828
+#: C/index.docbook:942
 msgid "Click <guibutton>OK</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:850
+#. (itstool) path: section/para
+#: C/index.docbook:830
 msgid "<application>Archive Manager</application> uses the password to encrypt the files that you add to the current archive, and to decrypt the files that you extract from the current archive. <application>Archive Manager</application> deletes the password when you close the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:852
+#. (itstool) path: section/para
+#: C/index.docbook:832
 msgid "For information on how to check whether an archive contains encrypted files, see <xref linkend=\"engrampa-extra-info\"/>."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:855
-msgid "The encryption provided by archive utilities is weak and insecure. If security is important, use a strong encryption tool such as <ulink url=\"http://www.gnupg.org\" type=\"http\">GNU Privacy Guard</ulink>."
+#: C/index.docbook:835
+msgid "The encryption provided by archive utilities is weak and insecure. If security is important, use a strong encryption tool such as <link xlink:href=\"http://www.gnupg.org\">GNU Privacy Guard</link>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:862
+#. (itstool) path: info/title
+#: C/index.docbook:841
 msgid "To Rename a File in an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:863
+#. (itstool) path: section/para
+#: C/index.docbook:843
 msgid "To rename a file in an archive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:866
+#: C/index.docbook:846
 msgid "Select the file that you want to rename."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:869
+#: C/index.docbook:849
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Rename</guimenuitem></menuchoice>, or press <keycombo><keycap>F2</keycap></keycombo>, to display the <guilabel>Rename</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:872
+#: C/index.docbook:852
 msgid "Enter the new filename in the <guilabel>New file name</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:875
+#: C/index.docbook:855
 msgid "Click <guibutton>Rename</guibutton>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:883
+#. (itstool) path: info/title
+#: C/index.docbook:862
 msgid "To Copy Files in an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:884
+#. (itstool) path: section/para
+#: C/index.docbook:864
 msgid "To copy files in an archive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:887
+#: C/index.docbook:867
 msgid "Select the files that you want to copy."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:890
+#: C/index.docbook:870
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Copy</guimenuitem></menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>C</keycap></keycombo>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:893
+#: C/index.docbook:873
 msgid "Open the location where you want to put the copied files."
 msgstr ""
 
 #. (itstool) path: listitem/para
+#: C/index.docbook:876
 #: C/index.docbook:896
-#: C/index.docbook:916
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Paste</guimenuitem></menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>V</keycap></keycombo>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:903
+#. (itstool) path: info/title
+#: C/index.docbook:882
 msgid "To Move Files in an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:904
+#. (itstool) path: section/para
+#: C/index.docbook:884
 msgid "To move files in an archive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:907
+#: C/index.docbook:887
 msgid "Select the files that you want to move."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:910
+#: C/index.docbook:890
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Cut</guimenuitem></menuchoice>, or press <keycombo><keycap>Ctrl</keycap><keycap>X</keycap></keycombo>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:913
+#: C/index.docbook:893
 msgid "Open the location where you want to put the moved files."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:923
+#. (itstool) path: info/title
+#: C/index.docbook:902
 msgid "To Delete Files From an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:924
+#. (itstool) path: section/para
+#: C/index.docbook:904
 msgid "To delete files from an archive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:927
+#: C/index.docbook:907
 msgid "Select the files that you want to delete."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:930
+#: C/index.docbook:910
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Delete</guimenuitem></menuchoice> or press <keycap>Delete</keycap> to display the <guilabel>Delete</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:933
+#: C/index.docbook:913
 msgid "Select one of the following delete options:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:936
-#: C/index.docbook:1570
+#: C/index.docbook:916
+#: C/index.docbook:1550
 msgid "<guilabel>All files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:938
+#: C/index.docbook:918
 msgid "Delete all files from the archive."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:944
-#: C/index.docbook:1578
+#: C/index.docbook:924
+#: C/index.docbook:1558
 msgid "<guilabel>Selected files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:946
+#: C/index.docbook:926
 msgid "Delete the selected files from the archive."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:952
-#: C/index.docbook:1586
+#: C/index.docbook:932
+#: C/index.docbook:1566
 msgid "<guilabel>Files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:954
+#: C/index.docbook:934
 msgid "Delete from the archive all files that match the specified pattern. See <xref linkend=\"engrampa-pattern\"/> for more information about filename patterns."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:970
+#. (itstool) path: info/title
+#: C/index.docbook:949
 msgid "To Modify a File in an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:974
+#: C/index.docbook:954
 msgid "Double-click the file that you want to open. Alternatively right-click the file and choose <menuchoice><guimenuitem>Open</guimenuitem></menuchoice>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:975
+#: C/index.docbook:955
 msgid "Edit the file opened in step 1, and then save your changes."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:976
+#: C/index.docbook:956
 msgid "<application>Archive Manager</application> shows a confirmation dialog, asking confirmation to update the file in the archive with the changes you made."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:977
+#: C/index.docbook:957
 msgid "Click on <guilabel>Update</guilabel>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:971
+#. (itstool) path: section/para
+#: C/index.docbook:951
 msgid "To modify a file in an archive perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:980
+#. (itstool) path: section/para
+#: C/index.docbook:960
 msgid "<application>Archive Manager</application> uses the system-defined associations between file types and programs to determine the appropriate application to launch for a specific file. These assocations can be displayed and modified in the <guilabel>Open With</guilabel> tab of the file properties dialog. If <application>Archive Manager</application> cannot determine the appropriate application, <application>Archive Manager</application> displays the <guilabel>Open Files</guilabel> dialog to let you choose an application, as described in below."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:983
+#. (itstool) path: info/title
+#: C/index.docbook:962
 msgid "To Modify a File in an Archive with a Custom Application"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:987
+#: C/index.docbook:967
 msgid "Right click the file."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:988
+#: C/index.docbook:968
 msgid "Choose <menuchoice><guimenuitem>Open With...</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:984
+#. (itstool) path: section/para
+#: C/index.docbook:964
 msgid "You can use an application specified by you, rather than the default application, to modify a file. To use an external application to open a file: <_:orderedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:991
+#. (itstool) path: section/para
+#: C/index.docbook:971
 msgid "<application>Archive Manager</application> displays the <guilabel>Open Files</guilabel> dialog, which lists all of the applications that can open files of the specified type. To select one of the applications, double-click the application name or click on the application name and then click <guibutton>Open</guibutton>. Alternatively, enter the application name in the <guilabel>Application</guilabel> text box and then click <guibutton>Open</guibutton> to launch the application of your choice."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:992
+#. (itstool) path: section/para
+#: C/index.docbook:972
 msgid "Once the application starts follow the procedure from step 2 as described in <xref linkend=\"engrampa-modify-archive-file\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1000
+#. (itstool) path: info/title
+#: C/index.docbook:979
 msgid "Viewing Archives"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1001
+#. (itstool) path: section/para
+#: C/index.docbook:981
 msgid "<application>Archive Manager</application> enables you to view several aspects of an archive."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1006
+#. (itstool) path: info/title
+#: C/index.docbook:985
 msgid "To View the Properties of an Archive"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1010
-#: C/index.docbook:1058
+#: C/index.docbook:990
+#: C/index.docbook:1038
 msgid "<guilabel>Name</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1011
+#: C/index.docbook:991
 msgid "The name of the archive."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
 #. (itstool) path: entry/para
-#: C/index.docbook:1015
-#: C/index.docbook:1078
-#: C/index.docbook:1257
+#: C/index.docbook:995
+#: C/index.docbook:1058
+#: C/index.docbook:1237
 msgid "<guilabel>Location</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1016
+#: C/index.docbook:996
 msgid "The position of the archive in the file system."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1020
+#: C/index.docbook:1000
 msgid "<guilabel>Modified on</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1021
+#: C/index.docbook:1001
 msgid "The date and time at which the archive was last modified."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1025
+#: C/index.docbook:1005
 msgid "<guilabel>Archive size</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1026
+#: C/index.docbook:1006
 msgid "The size of the archive contents when compressed."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1030
+#: C/index.docbook:1010
 msgid "<guilabel>Content size</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1031
+#: C/index.docbook:1011
 msgid "The size of the archive contents when uncompressed. This information is also available in the statusbar."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1036
+#: C/index.docbook:1016
 msgid "<guilabel>Compression ratio</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1037
+#: C/index.docbook:1017
 msgid "The compression ratio is a value used to describe the reduction in size of the data. For example a compression ratio of 5 means that the compressed archive is 1/5th the size of the original data."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1042
+#: C/index.docbook:1022
 msgid "<guilabel>Number of files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1043
+#: C/index.docbook:1023
 msgid "The number of files in the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1007
+#. (itstool) path: section/para
+#: C/index.docbook:987
 msgid "To view the properties of an archive, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Properties</guimenuitem></menuchoice> to display the <guilabel>Properties</guilabel> dialog. The <guilabel>Properties</guilabel> dialog displays the following information about the archive: <_:variablelist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1053
+#. (itstool) path: info/title
+#: C/index.docbook:1032
 msgid "To View the Contents of an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1059
+#: C/index.docbook:1039
 msgid "The name of a file or folder in the archive."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1063
+#: C/index.docbook:1043
 msgid "<guilabel>Size</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1064
+#: C/index.docbook:1044
 msgid "The size of the file when the file is extracted from the archive. For a folder, the <guilabel>Size</guilabel> field is blank. For information on how to display the size of the compressed file, see <xref linkend=\"engrampa-extra-info\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1068
+#: C/index.docbook:1048
 msgid "<guilabel>Type</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1069
+#: C/index.docbook:1049
 msgid "The type of the file. For a folder, the value in the <guilabel>Type</guilabel> field is <literal>Folder</literal>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1073
+#: C/index.docbook:1053
 msgid "<guilabel>Date modified</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1074
+#: C/index.docbook:1054
 msgid "The date on which the file was last modified. For a folder, the <guilabel>Date modified</guilabel> field is blank."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1079
+#: C/index.docbook:1059
 msgid "The path to the file within the archive. This column is visible only when the window is in file view, when in folder view the location of the files is displayed in the <guilabel>Location</guilabel> text box of the folderbar. For more information about view types see <xref linkend=\"engrampa-view-type-folder\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1055
+#. (itstool) path: section/para
+#: C/index.docbook:1035
 msgid "<application>Archive Manager</application> displays the archive contents in the main window as a file list with the following columns: <_:variablelist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1084
+#. (itstool) path: section/para
+#: C/index.docbook:1064
 msgid "If another program has modified the archive since <application>Archive Manager</application> opened the archive, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Reload</guimenuitem></menuchoice> to reload the archive contents from disk."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1086
+#. (itstool) path: section/para
+#: C/index.docbook:1066
 msgid "For information on how to customize the way that <application>Archive Manager</application> displays the archive contents, see <xref linkend=\"engrampa-archive-custom\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1088
+#. (itstool) path: section/para
+#: C/index.docbook:1068
 msgid "For more advanced tasks, use an application installed on your system. For more information, see <xref linkend=\"engrampa-view-archive-file\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1094
+#. (itstool) path: info/title
+#: C/index.docbook:1073
 msgid "To View a File in an Archive"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1095
+#. (itstool) path: section/para
+#: C/index.docbook:1075
 msgid "To view a file in an archive follow the steps described in <xref linkend=\"engrampa-modify-archive-file\"/>. If you save the opened file, click <guilabel>Cancel</guilabel> when <application>Archive Manager</application> asks confirmation to update the file in the archive."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1102
+#. (itstool) path: info/title
+#: C/index.docbook:1081
 msgid "To Test the Integrity of an Archive"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1106
+#: C/index.docbook:1086
 msgid "If the archive contains no errors, <application>Archive Manager</application> opens the <guilabel>Test Result</guilabel> dialog to list each file in the archive, and indicates that each file has status <literal>OK</literal>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1110
+#: C/index.docbook:1090
 msgid "If the archive contains some error, <application>Archive Manager</application> opens the <guilabel>Test Result</guilabel> dialog displaying the part of the archive contains the error."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1103
+#. (itstool) path: section/para
+#: C/index.docbook:1083
 msgid "Sometimes an archive can be damaged for some reason, to check whether an archive is damaged, choose <menuchoice><guimenu>Archive</guimenu><guimenuitem>Test Integrity</guimenuitem></menuchoice>: <_:itemizedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1115
+#. (itstool) path: section/para
+#: C/index.docbook:1095
 msgid "A damaged archive can be impossible to extract, this can bring to a loss of data. For this reason you should test the archive integrity before deleting the original files."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1117
+#. (itstool) path: section/para
+#: C/index.docbook:1097
 msgid "If the archive contains encrypted files, <application>Archive Manager</application> asks the password of the archive before performing the test."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1120
+#: C/index.docbook:1100
 msgid "Not all the archive types support the integrity testing, the following is the list of archive types that can be tested for integrity: 7-Zip, RAR, ZIP, ACE, ARJ and Zoo."
 msgstr ""
 
-#. (itstool) path: tip/title
-#: C/index.docbook:1124
-#: C/index.docbook:1425
+#. (itstool) path: info/title
+#: C/index.docbook:1103
+#: C/index.docbook:1404
 msgid "Tip"
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/index.docbook:1125
+#: C/index.docbook:1105
 msgid "To test the integrity of an archive that doesn't support the integrity testing, extract all the files from the archive and check that the operation is completed successfully."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1133
+#. (itstool) path: info/title
+#: C/index.docbook:1112
 msgid "Customizing the Archive Display"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1134
+#. (itstool) path: section/para
+#: C/index.docbook:1114
 msgid "You can customize the way that <application>Archive Manager</application> displays the archive contents, as follows:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1138
+#: C/index.docbook:1118
 msgid "Switch between folder view and file view. For more information, see <xref linkend=\"engrampa-view-type\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1142
+#: C/index.docbook:1122
 msgid "Specify the order in which to display files in the list. For more information, see <xref linkend=\"engrampa-view-sort\"/>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1146
+#: C/index.docbook:1126
 msgid "Display additional details about the contents of the archive. For more information, see <xref linkend=\"engrampa-extra-info\"/>."
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1150
+#. (itstool) path: section/para
+#: C/index.docbook:1130
 msgid "<application>Archive Manager</application> updates the display immediately, when you make any of the above customizations."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1154
+#. (itstool) path: info/title
+#: C/index.docbook:1133
 msgid "To Set the View Type"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1155
+#. (itstool) path: section/para
+#: C/index.docbook:1135
 msgid "If the archive contains folders, you can show the archive contents in either <link linkend=\"engrampa-view-type-folder\">folder view</link> or <link linkend=\"engrampa-view-type-file\">file view</link>."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:1159
+#. (itstool) path: info/title
+#: C/index.docbook:1138
 msgid "Folder View"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1160
+#. (itstool) path: section/para
+#: C/index.docbook:1140
 msgid "<application>Archive Manager</application> displays the archive contents in folder view by default. To explicitly select folder view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>View as a Folder</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1162
+#. (itstool) path: section/para
+#: C/index.docbook:1142
 msgid "In folder view, <application>Archive Manager</application> shows folders in the same way as a file manager shows folders. That is, <application>Archive Manager</application> indicates folders in the display area with a folder icon and the folder name. To view the contents of a folder, double-click on the folder name."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1164
+#. (itstool) path: section/para
+#: C/index.docbook:1144
 msgid "The folderbar, which <application>Archive Manager</application> displays only in folder view, contains the components described in the following table."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1173
+#: C/index.docbook:1153
 msgid "Component"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1175
+#: C/index.docbook:1155
 msgid "Description"
 msgstr ""
 
@@ -1800,18 +1755,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:1184
+#: C/index.docbook:1164
 msgctxt "_"
 msgid "external ref='figures/engrampa_leftarrow.png' md5='1878b2a4132b673aa79df7660398caa0'"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1181
+#: C/index.docbook:1161
 msgid "<inlinemediaobject> <imageobject> <imagedata fileref=\"figures/engrampa_leftarrow.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows icon to navigate backwards in location history list.</phrase> </textobject> </inlinemediaobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1193
+#: C/index.docbook:1173
 msgid "Click on this button to navigate backwards in the location history list."
 msgstr ""
 
@@ -1820,18 +1775,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:1203
+#: C/index.docbook:1183
 msgctxt "_"
 msgid "external ref='figures/engrampa_rightarrow.png' md5='45a0479ca13140680220976ccb653bda'"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1200
+#: C/index.docbook:1180
 msgid "<inlinemediaobject> <imageobject> <imagedata fileref=\"figures/engrampa_rightarrow.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows icon to navigate forwards in location history list.</phrase> </textobject> </inlinemediaobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1212
+#: C/index.docbook:1192
 msgid "Click on this button to navigate forwards in the location history list."
 msgstr ""
 
@@ -1840,18 +1795,18 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:1222
+#: C/index.docbook:1202
 msgctxt "_"
 msgid "external ref='figures/engrampa_uparrow.png' md5='097f01471c5575ceeb527ea8d50061bd'"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1219
+#: C/index.docbook:1199
 msgid "<inlinemediaobject> <imageobject> <imagedata fileref=\"figures/engrampa_uparrow.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows icon to navigate up one level in folder tree.</phrase> </textobject> </inlinemediaobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1231
+#: C/index.docbook:1211
 msgid "Click on this button to navigate up one level in the folder tree."
 msgstr ""
 
@@ -1860,543 +1815,573 @@ msgstr ""
 #. the file changes, the md5 hash will change to let you know you need to
 #. update your localized copy. The msgstr is not used at all. Set it to
 #. whatever you like once you have updated your copy of the file.
-#: C/index.docbook:1241
+#: C/index.docbook:1221
 msgctxt "_"
 msgid "external ref='figures/engrampa_home.png' md5='1cede2c4f8d21c357d0eb9979f39f18d'"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1238
+#: C/index.docbook:1218
 msgid "<inlinemediaobject> <imageobject> <imagedata fileref=\"figures/engrampa_home.png\" format=\"PNG\"/> </imageobject> <textobject> <phrase>Shows icon to open the top-level folder in the archive.</phrase> </textobject> </inlinemediaobject>"
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1250
+#: C/index.docbook:1230
 msgid "Click on this button to open the top-level folder in the archive."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1262
+#: C/index.docbook:1242
 msgid "This field shows the full pathname, within the archive, of the current folder."
 msgstr ""
 
 #. (itstool) path: entry/para
-#: C/index.docbook:1265
+#: C/index.docbook:1245
 msgid "To change to a different level in the folder tree, type the new location in the <guilabel>Location</guilabel> text box then press <keycap>Return</keycap>. <application>Archive Manager</application> displays the contents of the new location."
 msgstr ""
 
-#. (itstool) path: sect3/title
-#: C/index.docbook:1275
+#. (itstool) path: info/title
+#: C/index.docbook:1254
 msgid "File View"
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1276
+#. (itstool) path: section/para
+#: C/index.docbook:1256
 msgid "To select file view, choose <menuchoice><guimenu>View</guimenu><guimenuitem>View All Files</guimenuitem></menuchoice>."
 msgstr ""
 
-#. (itstool) path: sect3/para
-#: C/index.docbook:1278
+#. (itstool) path: section/para
+#: C/index.docbook:1258
 msgid "In file view, <application>Archive Manager</application> displays all files in the archive, including files from subfolders, in a single list."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1285
+#. (itstool) path: info/title
+#: C/index.docbook:1264
 msgid "To Sort the File List"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1286
+#. (itstool) path: section/para
+#: C/index.docbook:1266
 msgid "You can sort the file list by name, size, type, modification date, or location."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1287
+#. (itstool) path: section/para
+#: C/index.docbook:1267
 msgid "To specify a sort order, click on the heading of the corresponding column."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1288
+#. (itstool) path: section/para
+#: C/index.docbook:1268
 msgid "To reverse the sort order, click on the column heading again."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1290
+#. (itstool) path: section/para
+#: C/index.docbook:1270
 msgid "For example, to sort the file list by modification date, click on the <guilabel>Date modified</guilabel> heading. <application>Archive Manager</application> rearranges the file list to display the files by modification date, starting with the earliest. To display the latest files first, click on the <guilabel>Date modified</guilabel> heading again."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1292
+#. (itstool) path: section/para
+#: C/index.docbook:1272
 msgid "<application>Archive Manager</application> always performs a secondary sort based on the file name. In the above example, <application>Archive Manager</application> sorts by name any files that have the same modification date."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1297
+#. (itstool) path: info/title
+#: C/index.docbook:1276
 msgid "To Display Additional Details"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1301
+#: C/index.docbook:1281
 msgid "If you tested the archive in the current <application>Archive Manager</application> session, the <guilabel>Last Output</guilabel> dialog displays the results of the last test."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1305
+#: C/index.docbook:1285
 msgid "If you did not test the archive in the current <application>Archive Manager</application> session, the <guilabel>Last Output</guilabel> dialog displays a list of all files in the archive, but does not indicate any status for the files. Instead, the <guilabel>Last Output</guilabel> dialog provides the compressed size of each file and the percentage of compression, and the date and time at which the file was last modified."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1298
+#. (itstool) path: section/para
+#: C/index.docbook:1278
 msgid "To open the <guilabel>Last Output</guilabel> dialog, choose <menuchoice><guimenu>View</guimenu><guimenuitem>Last Output</guimenuitem></menuchoice>: <_:itemizedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1316
+#. (itstool) path: info/title
+#: C/index.docbook:1295
 msgid "Using the File Manager to Work with an Archive"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1317
+#. (itstool) path: section/para
+#: C/index.docbook:1297
 msgid "You can use the file manager to add files to an archive, or to extract files from an archive."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1322
+#. (itstool) path: info/title
+#: C/index.docbook:1301
 msgid "To Add Files to an Archive by Using the File Manager"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1325
+#: C/index.docbook:1305
 msgid "Drag the files into a <application>Archive Manager</application> window from a file manager window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1327
+#: C/index.docbook:1307
 msgid "Use the file manager popup menu to add the files to the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1323
+#. (itstool) path: section/para
+#: C/index.docbook:1303
 msgid "You can use the file manager to add files to an archive, in the following ways: <_:itemizedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1331
+#. (itstool) path: section/para
+#: C/index.docbook:1311
 msgid "To use the file manager popup menu to add files to an archive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1333
+#: C/index.docbook:1313
 msgid "Right-click on the files or folders in a file manager window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1335
+#: C/index.docbook:1315
 msgid "Choose <guimenuitem>Create Archive</guimenuitem> from the file manager popup menu to display the <application>Archive Manager</application> <guilabel>Create Archive</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1337
+#: C/index.docbook:1317
 msgid "Enter the archive name, without the file extension, in the <guilabel>Archive</guilabel> text box."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1339
+#: C/index.docbook:1319
 msgid "Choose the archive type from the drop-down list."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1341
+#: C/index.docbook:1321
 msgid "Choose the location where to save the archive file, from the <guilabel>Location</guilabel> drop-down list. If the location is not present in the list choose <guilabel>Other...</guilabel> to select it with the <guilabel>Location</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1346
+#: C/index.docbook:1326
 msgid "Click <guilabel>Create</guilabel> to add the selected files to the root folder of the specified archive."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1348
+#: C/index.docbook:1328
 msgid "To select any of the advanced add options, you must invoke <application>Archive Manager</application> as described in <xref linkend=\"engrampa-to-start\"/>."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1355
+#. (itstool) path: info/title
+#: C/index.docbook:1334
 msgid "To Extract Files From an Archive by Using the File Manager"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1358
+#: C/index.docbook:1338
 msgid "Drag the files from a <application>Archive Manager</application> window into a file manager window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1360
+#: C/index.docbook:1340
 msgid "Use the file manager popup menu to extract the files from the archive."
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1356
+#. (itstool) path: section/para
+#: C/index.docbook:1336
 msgid "You can use the file manager to extract files from an archive, in the following ways: <_:itemizedlist-1/>"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1364
+#. (itstool) path: section/para
+#: C/index.docbook:1344
 msgid "To use the file manager popup menu to extract files from an archive, perform the following steps:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1366
+#: C/index.docbook:1346
 msgid "Right-click on the archive in a file manager window."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1368
+#: C/index.docbook:1348
 msgid "Choose <guimenuitem>Extract Here</guimenuitem> to extract all of the archive contents into the directory where the archive is located."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1371
+#: C/index.docbook:1351
 msgid "If the archive is encrypted, <application>Archive Manager</application> will ask to enter the password before extracting the files."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1378
+#. (itstool) path: info/title
+#: C/index.docbook:1357
 msgid "Create Options"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1379
+#. (itstool) path: section/para
+#: C/index.docbook:1359
 msgid "When creating a new archive, or when converting an existing archive to another format, click on <guilabel>Other Options</guilabel> to specify the following advanced options:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1384
+#: C/index.docbook:1364
 msgid "<guilabel>Password</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1386
+#: C/index.docbook:1366
 msgid "Type the password that will be used to encrypt the archive. If no password is specified the archive will not be encrypted."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1388
+#: C/index.docbook:1368
 msgid "Not all archive types support encryption. For more information about file encryption, see <xref linkend=\"engrampa-encrypt-files\"/>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1393
+#: C/index.docbook:1373
 msgid "<guilabel>Encrypt the file list too</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1395
+#: C/index.docbook:1375
 msgid "If this option is selected, the password will be requested even to view the list of files contained in the archive, otherwise it will be requested only to extract the files from the archive. This option is available only if a password is specified."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1399
+#: C/index.docbook:1379
 msgid "<guilabel>Split in volumes</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1401
+#: C/index.docbook:1381
 msgid "Select this option to split the archive in more files of the specified dimension."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1403
+#: C/index.docbook:1383
 msgid "Only 7-Zip and RAR archives support this feature."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1412
+#. (itstool) path: info/title
+#: C/index.docbook:1391
 msgid "Add Options"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1413
+#. (itstool) path: section/para
+#: C/index.docbook:1393
 msgid "The <guilabel>Add Files</guilabel> and <guilabel>Add a Folder</guilabel> dialogs provide the following option:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1418
+#: C/index.docbook:1398
 msgid "<guilabel>Add only if newer</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1420
+#: C/index.docbook:1400
 msgid "Select this option to add the specified file to the archive only if the archive does not contain the specified file, or if the archive contains an older version of the specified file. <application>Archive Manager</application> uses the modification date to determine which file is the most recent. If the version of the file in the archive is the most recent, <application>Archive Manager</application> does not add the specified file to the archive."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1422
+#: C/index.docbook:1402
 msgid "If you do not select this option, <application>Archive Manager</application> adds the file to the archive and overwrites the previous archive contents."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1429
+#: C/index.docbook:1409
 msgid "Open the <filename>backup.tar.gz</filename> archive in <application>Archive Manager</application>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1434
+#: C/index.docbook:1414
 msgid "Choose <menuchoice><guimenu>Edit</guimenu><guimenuitem>Add</guimenuitem></menuchoice> to display the <guilabel>Add a Folder</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1438
+#: C/index.docbook:1418
 msgid "Select your home folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1443
+#: C/index.docbook:1423
 msgid "Select the <guilabel>Add only if newer</guilabel> option."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1448
+#: C/index.docbook:1428
 msgid "Click <guibutton>Add</guibutton>."
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/index.docbook:1426
+#: C/index.docbook:1406
 msgid "If you use <application>Archive Manager</application> to create backups, the <guilabel>Add only if newer</guilabel> option is very useful. For example, the archive <filename>backup.tar.gz</filename> contains a week-old backup of your home folder. To update the archive to contain a current backup of your home folder, perform the following steps: <_:orderedlist-1/>"
 msgstr ""
 
 #. (itstool) path: tip/para
-#: C/index.docbook:1454
+#: C/index.docbook:1434
 msgid "<application>Archive Manager</application> automatically adds to the archive all files that you created during the last week, and updates all files that you modified during the last week. However, <application>Archive Manager</application> does not remove from the archive the files that you deleted during the last week. The archive update operation is much faster than doing a full backup of your home folder."
 msgstr ""
 
-#. (itstool) path: sect2/title
-#: C/index.docbook:1461
+#. (itstool) path: info/title
+#: C/index.docbook:1440
 msgid "Add to Folder Options"
 msgstr ""
 
-#. (itstool) path: sect2/para
-#: C/index.docbook:1462
+#. (itstool) path: section/para
+#: C/index.docbook:1442
 msgid "The following options are available in the <guilabel>Add a Folder</guilabel> dialog and allow to automatically select and add all files that satisfy certain criteria:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1467
+#: C/index.docbook:1447
 msgid "<guilabel>Include files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1469
+#: C/index.docbook:1449
 msgid "Type a filename pattern in this text box to include files with names that match the specified pattern. See <xref linkend=\"engrampa-pattern\"/> for more information about filename patterns."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1475
+#: C/index.docbook:1455
 msgid "<guilabel>Exclude files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1477
+#: C/index.docbook:1457
 msgid "Type a filename pattern in this text box to exclude files with names that match the specified pattern. See <xref linkend=\"engrampa-pattern\"/> for more information about filename patterns."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1483
+#: C/index.docbook:1463
 msgid "<guilabel>Exclude folders</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1485
+#: C/index.docbook:1465
 msgid "Type a filename pattern in this text box to exclude folders with names that match the specified pattern. See <xref linkend=\"engrampa-pattern\"/> for more information about filename patterns."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1491
+#: C/index.docbook:1471
 msgid "<guilabel>Include subfolders</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1493
+#: C/index.docbook:1473
 msgid "Select this option to add all files that match the specified pattern, from the current folder and from subfolders."
 msgstr ""
 
 #. (itstool) path: note/para
-#: C/index.docbook:1496
+#: C/index.docbook:1476
 msgid "The filename, not the subfolder name, must match the specified pattern."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1500
+#: C/index.docbook:1480
 msgid "If you do not select this option, <application>Archive Manager</application> adds the matching files from the current folder only."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1506
+#: C/index.docbook:1486
 msgid "<guilabel>Exclude folders that are symbolic links</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1508
+#: C/index.docbook:1488
 msgid "Select this option to omit files from folders that are symbolic links. Symbolic links are pointers or shortcuts to other folders."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1510
+#: C/index.docbook:1490
 msgid "If you do not select this option, <application>Archive Manager</application> adds the matching files from folders that are symbolic links."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1516
+#: C/index.docbook:1496
 msgid "<guibutton>Save Options</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1518
+#: C/index.docbook:1498
 msgid "Click on this button to save the current selection of advanced add options to a file. The <guilabel>Save Options</guilabel> dialog is displayed. Enter a descriptive filename in the <guilabel>Options Name</guilabel> text box, then click <guibutton>Save</guibutton>."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1524
+#: C/index.docbook:1504
 msgid "<guibutton>Load Options</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1526
+#: C/index.docbook:1506
 msgid "Click on this button to load or delete a previously saved selection of advanced add options. The <guilabel>Load Options</guilabel> dialog is displayed."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1529
+#: C/index.docbook:1509
 msgid "To load a set of options, select the options file in the list box, then click <guibutton>Apply</guibutton>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1534
+#: C/index.docbook:1514
 msgid "To delete a set of options, select the options file in the list box, then click <guibutton>Remove</guibutton>. Click <guibutton>Close</guibutton> to close the <guilabel>Load Options</guilabel> dialog."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1543
+#: C/index.docbook:1523
 msgid "<guibutton>Reset Options</guibutton>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1545
+#: C/index.docbook:1525
 msgid "Click on this button to reset the current selection of advanced add options to the default values."
 msgstr ""
 
-#. (itstool) path: sect1/title
-#: C/index.docbook:1555
+#. (itstool) path: info/title
+#: C/index.docbook:1534
 msgid "Extract Options"
 msgstr ""
 
-#. (itstool) path: sect1/para
-#: C/index.docbook:1557
+#. (itstool) path: section/para
+#: C/index.docbook:1537
 msgid "The <guilabel>Extract</guilabel> dialog provides the following options, which are saved when you quit <application>Archive Manager</application>:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1563
+#: C/index.docbook:1543
 msgid "<guilabel>Extract</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1565
+#: C/index.docbook:1545
 msgid "Select the files to be extracted:"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1572
+#: C/index.docbook:1552
 msgid "Extract all files from the archive."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1580
+#: C/index.docbook:1560
 msgid "Extract the selected files from the archive."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1588
+#: C/index.docbook:1568
 msgid "Extract from the archive all files that match the specified pattern. See <xref linkend=\"engrampa-pattern\"/> for more information about filename patterns."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1598
+#: C/index.docbook:1578
 msgid "<guilabel>Actions</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1600
+#: C/index.docbook:1580
 msgid "Select the following extract options:"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1605
+#: C/index.docbook:1585
 msgid "<guilabel>Re-create folders</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1606
+#: C/index.docbook:1586
 msgid "Select this option to reconstruct the folder structure when extracting the specified files."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1610
+#: C/index.docbook:1590
 msgid "If you select the <guilabel>Re-create folders</guilabel> option, <application>Archive Manager</application> extracts the contents of the subfolder to <filename>/tmp/doc</filename>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1614
+#: C/index.docbook:1594
 msgid "If you do not select the <guilabel>Re-create folders</guilabel> option, <application>Archive Manager</application> does not create any subfolders. Instead, <application>Archive Manager</application> extracts all files from the archive, including files from subfolders, to <filename>/tmp</filename>."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1608
+#: C/index.docbook:1588
 msgid "For example, you specify <filename>/tmp</filename> in the <guilabel>Filename</guilabel> text box and choose to extract all files. The archive contains a subfolder called <filename>doc</filename>. <_:itemizedlist-1/>"
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1623
+#: C/index.docbook:1603
 msgid "<guilabel>Overwrite existing files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1624
+#: C/index.docbook:1604
 msgid "Select this option to overwrite any files in the destination folder that have the same name as the specified files."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1626
+#: C/index.docbook:1606
 msgid "If you do not select this option, <application>Archive Manager</application> does not extract the specified file if an existing file with the same name already exists in the destination folder."
 msgstr ""
 
 #. (itstool) path: varlistentry/term
-#: C/index.docbook:1632
+#: C/index.docbook:1612
 msgid "<guilabel>Do not extract older files</guilabel>"
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1634
+#: C/index.docbook:1614
 msgid "This option is only effective while the <guilabel>Overwrite existing files</guilabel> option is selected."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1636
+#: C/index.docbook:1616
 msgid "Select the <guilabel>Do not extract older files</guilabel> option to extract the specified file only if the destination folder does not contain the specified file, or if the destination folder contains an older version of the specified file. <application>Archive Manager</application> uses the modification date to determine which file is the most recent. If the version of the file in the archive is older, <application>Archive Manager</application> does not extract the specified file to the destination folder."
 msgstr ""
 
 #. (itstool) path: listitem/para
-#: C/index.docbook:1638
+#: C/index.docbook:1618
 msgid "If you do not select the <guilabel>Do not extract older files</guilabel> option while the <guilabel>Overwrite existing files</guilabel> option is selected, <application>Archive Manager</application> extracts the specified file from the archive and overwrites the previous contents of the destination folder."
 msgstr ""
 
-#. (itstool) path: para/ulink
-#: C/legal.xml:9
-msgid "link"
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:4
+msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <link xlink:href=\"https://www.gnu.org/licenses/fdl-1.1.html\">link</link> or in the file COPYING-DOCS distributed with this manual."
 msgstr ""
 
 #. (itstool) path: legalnotice/para
-#: C/legal.xml:2
-msgid "Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License (GFDL), Version 1.1 or any later version published by the Free Software Foundation with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts. You can find a copy of the GFDL at this <_:ulink-1/> or in the file COPYING-DOCS distributed with this manual."
+#: C/legal.xml:13
+msgid "This manual is part of a collection of MATE manuals distributed under the GFDL. If you want to distribute this manual separately from the collection, you can do so by adding a copy of the license to the manual, as described in section 6 of the license."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:20
+msgid "Many of the names used by companies to distinguish their products and services are claimed as trademarks. Where those names appear in any MATE documentation, and the members of the MATE Documentation Project are made aware of those trademarks, then the names are in capital letters or initial capital letters."
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/legal.xml:36
+msgid "DOCUMENT IS PROVIDED ON AN \"AS IS\" BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS FREE OF DEFECTS MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY, ACCURACY, AND PERFORMANCE OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS WITH YOU. SHOULD ANY DOCUMENT OR MODIFIED VERSION PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE INITIAL WRITER, AUTHOR OR ANY CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS DISCLAIMER; AND"
+msgstr ""
+
+#. (itstool) path: listitem/para
+#: C/legal.xml:56
+msgid "UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE AUTHOR, INITIAL WRITER, ANY CONTRIBUTOR, OR ANY DISTRIBUTOR OF THE DOCUMENT OR MODIFIED VERSION OF THE DOCUMENT, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER DAMAGES OR LOSSES ARISING OUT OF OR RELATING TO USE OF THE DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES."
+msgstr ""
+
+#. (itstool) path: legalnotice/para
+#: C/legal.xml:29
+msgid "DOCUMENT AND MODIFIED VERSIONS OF THE DOCUMENT ARE PROVIDED UNDER THE TERMS OF THE GNU FREE DOCUMENTATION LICENSE WITH THE FURTHER UNDERSTANDING THAT: <_:orderedlist-1/>"
+msgstr ""
+
+#. (itstool) path: formalpara/title
+#: C/legal.xml:77
+msgid "Feedback"
+msgstr ""
+
+#. (itstool) path: formalpara/para
+#: C/legal.xml:78
+msgid "To report a bug or make a suggestion regarding the <application>Archive Manager</application> application or this manual, follow the directions in the <link xlink:href=\"help:mate-user-guide/feedback\">MATE Feedback Page</link>."
 msgstr ""
 

--- a/help/engrampa.pot
+++ b/help/engrampa.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: MATE Desktop Environment\n"
-"POT-Creation-Date: 2019-02-07 12:02+0100\n"
+"POT-Creation-Date: 2019-03-10 00:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 
 #. (itstool) path: info/copyright
 #: C/index.docbook:21
-msgid "<year>2015</year> <holder>MATE Documentation Project</holder>"
+msgid "<year>2019</year> <holder>MATE Documentation Project</holder>"
 msgstr ""
 
 #. (itstool) path: info/copyright
@@ -183,7 +183,7 @@ msgstr ""
 
 #. (itstool) path: info/releaseinfo
 #: C/index.docbook:199
-msgid "This manual describes version 1.10 of Archive Manager."
+msgid "This manual describes version 1.22 of Archive Manager."
 msgstr ""
 
 #. (itstool) path: article/indexterm
@@ -338,7 +338,7 @@ msgstr ""
 
 #. (itstool) path: entry/para
 #: C/index.docbook:292
-msgid "<filename>.deb</filename>"
+msgid "<filename>.deb</filename>, <filename>.udeb</filename>"
 msgstr ""
 
 #. (itstool) path: entry/para


### PR DESCRIPTION
To upgrade the manual:
  sudo dnf install -y docbook5-schemas
  xsltproc --output index-new.docbook /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl index.docbook
  xsltproc --output legal-new.xml /usr/share/xml/docbook5/stylesheet/upgrade/db4-upgrade.xsl legal.xml

To validate the manual:
  xmllint --noout --relaxng /usr/share/xml/docbook5/schema/rng/5.0/docbook.rng help/C/index.docbook
  jing /usr/share/xml/docbook5/schema/rng/5.0/docbook.rng help/C/index.docbook
  yelp-check validate help/C/index.docbook

To view the manual:
  yelp file:///full_path/index.docbook

Note: docbook5-schemas should be installed in your system in order to view the manual (DEPENDENCY)