### PR TITLE
fr-process: Fix memory leak

### DIFF
--- a/src/fr-process.c
+++ b/src/fr-process.c
@@ -736,10 +736,8 @@ start_current_command (FrProcess *process)
 	}
 #endif
 
-	if ((fixname) && (system(commandline) != 0)) {
+	if ((fixname) && (system(commandline) != 0))
 		g_warning ("The files could not be move: %s\n", commandline);
-		return;
-	}
 
 	if (info->begin_func != NULL)
 		(*info->begin_func) (info->begin_data);


### PR DESCRIPTION
Fixes Clang static analyzer warning:

fr-process.c:740:3: warning: Potential leak of memory pointed to by 'argv'
                g_warning ("The files could not be move: %s\n", commandline);
                ^~~~~~~~~