### PR TITLE
file-utils: avoid out of bound memory access

### DIFF
--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -445,7 +445,7 @@ const gchar* file_name_from_path(const gchar *file_name)
 	if (file_name == NULL)
 		return NULL;
 
-	if (file_name[0] == '\0')
+	if ((file_name[0] == '\0') || (strlen (file_name) == 0))
 		return "";
 
 	last_char = strlen (file_name) - 1;


### PR DESCRIPTION
Fixes Clang static analyzer warning:

```
file-utils.c:453:6: warning: Out of bound memory access (access exceeds upper limit of memory block)
        if (file_name [last_char] == G_DIR_SEPARATOR)
            ^~~~~~~~~~~~~~~~~~~~~
```