### PR TITLE
Use 'strnlen' instead of 'strlen'

### DIFF
--- a/copy-n-paste/eggsmclient-xsmp.c
+++ b/copy-n-paste/eggsmclient-xsmp.c
@@ -1144,7 +1144,7 @@ array_prop (const char *name, ...)
   va_start (ap, name);
   while ((value = va_arg (ap, char *)))
     {
-      pv.length = strlen (value);
+      pv.length = strnlen (value, BUFSIZ);
       pv.value = value;
       g_array_append_val (vals, pv);
     }
@@ -1178,7 +1178,7 @@ ptrarray_prop (const char *name, GPtrArray *values)
 
   for (i = 0; i < values->len; i++)
     {
-      pv.length = strlen (values->pdata[i]);
+      pv.length = strnlen (values->pdata[i], BUFSIZ);
       pv.value = values->pdata[i];
       g_array_append_val (vals, pv);
     }
@@ -1207,7 +1207,7 @@ string_prop (const char *name, const char *value)
   prop->num_vals = 1;
   prop->vals = g_new (SmPropValue, 1);
 
-  prop->vals[0].length = strlen (value);
+  prop->vals[0].length = strnlen (value, BUFSIZ);
   prop->vals[0].value = (char *)value;
 
   return prop;

--- a/src/dlg-new.c
+++ b/src/dlg-new.c
@@ -215,7 +215,7 @@ format_chooser_selection_changed_cb (EggFileFormatChooser *format_chooser,
 		new_ext = mime_type_desc[data->supported_types[n_format - 1]].default_ext;
 		basename = file_name_from_path (uri);
 		if (g_str_has_suffix (basename, ext))
-			basename_noext = g_strndup (basename, strlen (basename) - strlen (ext));
+			basename_noext = g_strndup (basename, strnlen (basename, BUFSIZ) - strnlen (ext, BUFSIZ));
 		else
 			basename_noext = g_strdup (basename);
 		new_basename = g_strconcat (basename_noext, new_ext, NULL);

--- a/src/eggfileformatchooser.c
+++ b/src/eggfileformatchooser.c
@@ -313,13 +313,13 @@ accept_filename (gchar       *extensions,
   gchar *token;
   gsize length;
 
-  length = strlen (filename);
+  length = strnlen (filename, BUFSIZ);
 
   for (token = strtok_r (extensions, ",", &saveptr); NULL != token;
        token = strtok_r (NULL, ",", &saveptr))
     {
       token = g_strstrip (token);
-      extptr = filename + length - strlen (token) - 1;
+      extptr = filename + length - strnlen (token, BUFSIZ) - 1;
 
       if (extptr > filename && '.' == *extptr &&
           !strcmp (extptr + 1, token))

--- a/src/file-data.c
+++ b/src/file-data.c
@@ -20,6 +20,7 @@
  *  Foundation, Inc., 59 Temple Street #330, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
 #include <config.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
@@ -154,7 +155,7 @@ find_path_in_file_data_array (GPtrArray  *array,
 	if (path == NULL)
 		return -1;
 
-	path_l = strlen (path);
+	path_l = strnlen (path, BUFSIZ);
 	left = 0;
 	right = array->len;
 	while (left < right) {
@@ -165,7 +166,7 @@ find_path_in_file_data_array (GPtrArray  *array,
 		if (cmp != 0) {
 			/* consider '/path/to/dir' and '/path/to/dir/' the same path */
 
-			int original_path_l = strlen (fd->original_path);
+			int original_path_l = strnlen (fd->original_path, BUFSIZ);
 			if ((path_l == original_path_l - 1) && (fd->original_path[original_path_l - 1] == '/')) {
 				int cmp2 = strncmp (path, fd->original_path, original_path_l - 1);
 				if (cmp2 == 0)

--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -302,8 +302,8 @@ path_in_path (const char *dirname,
 	if ((dirname == NULL) || (filename == NULL))
 		return FALSE;
 
-	dirname_l = strlen (dirname);
-	filename_l = strlen (filename);
+	dirname_l = strnlen (dirname, BUFSIZ);
+	filename_l = strnlen (filename, BUFSIZ);
 
 	if ((dirname_l == filename_l + 1)
 	     && (dirname[dirname_l - 1] == '/'))
@@ -445,10 +445,10 @@ const gchar* file_name_from_path(const gchar *file_name)
 	if (file_name == NULL)
 		return NULL;
 
-	if ((file_name[0] == '\0') || (strlen (file_name) == 0))
+	if ((file_name[0] == '\0') || (strnlen (file_name, BUFSIZ) == 0))
 		return "";
 
-	last_char = strlen (file_name) - 1;
+	last_char = strnlen (file_name, BUFSIZ) - 1;
 
 	if (file_name [last_char] == G_DIR_SEPARATOR)
 		return "";
@@ -473,7 +473,7 @@ dir_name_from_path (const gchar *path)
 	if (path[0] == '\0')
 		return g_strdup ("");
 
-	last_char = strlen (path) - 1;
+	last_char = strnlen (path, BUFSIZ) - 1;
 	if (path[last_char] == G_DIR_SEPARATOR)
 		last_char--;
 
@@ -495,7 +495,7 @@ remove_level_from_path (const gchar *path)
 	if (path == NULL)
 		return NULL;
 
-	p = strlen (path) - 1;
+	p = strnlen (path, BUFSIZ) - 1;
 	if (p < 0)
 		return NULL;
 
@@ -517,7 +517,7 @@ remove_ending_separator (const char *path)
 	if (path == NULL)
 		return NULL;
 
-	copy_len = len = strlen (path);
+	copy_len = len = strnlen (path, BUFSIZ);
 	if ((len > 1) && (path[len - 1] == '/'))
 		copy_len--;
 
@@ -557,7 +557,7 @@ remove_extension_from_path (const gchar *path)
 	if (! path)
 		return NULL;
 
-	len = strlen (path);
+	len = strnlen (path, BUFSIZ);
 	if (len == 1)
 		return g_strdup (path);
 
@@ -662,7 +662,7 @@ get_file_extension (const char *filename)
 	if (filename == NULL)
 		return NULL;
 
-	len = strlen (filename);
+	len = strnlen (filename, BUFSIZ);
 	if (len <= 1)
 		return NULL;
 
@@ -688,8 +688,8 @@ file_extension_is (const char *filename,
 {
 	int filename_l, ext_l;
 
-	filename_l = strlen (filename);
-	ext_l = strlen (ext);
+	filename_l = strnlen (filename, BUFSIZ);
+	ext_l = strnlen (ext, BUFSIZ);
 
 	if (filename_l < ext_l)
 		return FALSE;
@@ -962,8 +962,8 @@ is_temp_work_dir (const char *dir)
 
 	for (i = 0; try_folder[i] != NULL; i++) {
 		folder = ith_temp_folder_to_try (i);
-		if (strncmp (dir, folder, strlen (folder)) == 0)
-			if (strncmp (dir + strlen (folder), "/.fr-", 5) == 0) {
+		if (strncmp (dir, folder, strnlen (folder, BUFSIZ)) == 0)
+			if (strncmp (dir + strnlen (folder, BUFSIZ), "/.fr-", 5) == 0) {
 				g_free (folder);
 				return TRUE;
 			}
@@ -1032,8 +1032,8 @@ file_list__get_index_from_pattern (const char *line,
 	int         line_l, pattern_l;
 	const char *l;
 
-	line_l = strlen (line);
-	pattern_l = strlen (pattern);
+	line_l = strnlen (line, BUFSIZ);
+	pattern_l = strnlen (pattern, BUFSIZ);
 
 	if ((pattern_l == 0) || (line_l == 0))
 		return -1;

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -1351,8 +1351,8 @@ create_tmp_base_dir (const char *base_dir,
 	}
 
 	dest_dir = g_strdup (dest_path);
-	if (dest_dir[strlen (dest_dir) - 1] == G_DIR_SEPARATOR)
-		dest_dir[strlen (dest_dir) - 1] = 0;
+	if (dest_dir[strnlen (dest_dir, BUFSIZ) - 1] == G_DIR_SEPARATOR)
+		dest_dir[strnlen (dest_dir, BUFSIZ) - 1] = 0;
 
 	debug (DEBUG_INFO, "base_dir: %s\n", base_dir);
 	debug (DEBUG_INFO, "dest_dir: %s\n", dest_dir);
@@ -1459,7 +1459,7 @@ save_list_to_temp_file (GList   *file_list,
 			char *filename = scan->data;
 
 			filename = str_substitute (filename, "\n", "\\n");
-			if ((g_output_stream_write (G_OUTPUT_STREAM (ostream), filename, strlen (filename), NULL, error) < 0)
+			if ((g_output_stream_write (G_OUTPUT_STREAM (ostream), filename, strnlen (filename, BUFSIZ), NULL, error) < 0)
 			    || (g_output_stream_write (G_OUTPUT_STREAM (ostream), "\n", 1, NULL, error) < 0))
 			{
 				error_occurred = TRUE;
@@ -1508,11 +1508,11 @@ split_in_chunks (GList *file_list)
 		l = 0;
 		while ((scan != NULL) && (l < MAX_CHUNK_LEN)) {
 			if (l == 0)
-				l = strlen (scan->data);
+				l = strnlen (scan->data, BUFSIZ);
 			prev = scan;
 			scan = scan->next;
 			if (scan != NULL)
-				l += strlen (scan->data);
+				l += strnlen (scan->data, BUFSIZ);
 		}
 		if (prev != NULL) {
 			if (prev->next != NULL)
@@ -2537,7 +2537,7 @@ delete_from_archive (FrArchive *archive,
 		for (scan = file_list; scan != NULL; scan = scan->next) {
 			char *path = scan->data;
 
-			if (path[strlen (path) - 1] == '/')
+			if (path[strnlen (path, BUFSIZ) - 1] == '/')
 				folders_to_remove = g_list_prepend (folders_to_remove, path);
 		}
 
@@ -2596,11 +2596,11 @@ delete_from_archive (FrArchive *archive,
 			l = 0;
 			while ((scan != NULL) && (l < MAX_CHUNK_LEN)) {
 				if (l == 0)
-					l = strlen (scan->data);
+					l = strnlen (scan->data, BUFSIZ);
 				prev = scan;
 				scan = scan->next;
 				if (scan != NULL)
-					l += strlen (scan->data);
+					l += strnlen (scan->data, BUFSIZ);
 			}
 
 			prev->next = NULL;
@@ -2780,7 +2780,7 @@ move_files_in_chunks (FrArchive  *archive,
 	GList *scan;
 	int    temp_dir_l;
 
-	temp_dir_l = strlen (temp_dir);
+	temp_dir_l = strnlen (temp_dir, BUFSIZ);
 
 	for (scan = file_list; scan != NULL; ) {
 		GList *prev = scan->prev;
@@ -2791,11 +2791,11 @@ move_files_in_chunks (FrArchive  *archive,
 		l = 0;
 		while ((scan != NULL) && (l < MAX_CHUNK_LEN)) {
 			if (l == 0)
-				l = temp_dir_l + 1 + strlen (scan->data);
+				l = temp_dir_l + 1 + strnlen (scan->data, BUFSIZ);
 			prev = scan;
 			scan = scan->next;
 			if (scan != NULL)
-				l += temp_dir_l + 1 + strlen (scan->data);
+				l += temp_dir_l + 1 + strnlen (scan->data, BUFSIZ);
 		}
 
 		prev->next = NULL;
@@ -2868,11 +2868,11 @@ extract_from_archive (FrArchive  *archive,
 			l = 0;
 			while ((scan != NULL) && (l < MAX_CHUNK_LEN)) {
 				if (l == 0)
-					l = strlen (scan->data);
+					l = strnlen (scan->data, BUFSIZ);
 				prev = scan;
 				scan = scan->next;
 				if (scan != NULL)
-					l += strlen (scan->data);
+					l += strnlen (scan->data, BUFSIZ);
 			}
 
 			prev->next = NULL;
@@ -2895,8 +2895,8 @@ compute_base_path (const char *base_dir,
 		   gboolean    junk_paths,
 		   gboolean    can_junk_paths)
 {
-	int         base_dir_len = strlen (base_dir);
-	int         path_len = strlen (path);
+	int         base_dir_len = strnlen (base_dir, BUFSIZ);
+	int         path_len = strnlen (path, BUFSIZ);
 	const char *base_path;
 	char       *name_end;
 	char       *new_path;
@@ -3011,7 +3011,7 @@ remove_files_contained_in_this_dir (GList *file_list,
 				    GList *dir_pointer)
 {
 	char  *dirname = dir_pointer->data;
-	int    dirname_l = strlen (dirname);
+	int    dirname_l = strnlen (dirname, BUFSIZ);
 	GList *scan;
 
 	for (scan = dir_pointer->next; scan; /* empty */) {
@@ -3161,7 +3161,7 @@ fr_archive_extract_to_local (FrArchive  *archive,
 		else
 			filename = file_name_from_path (archive_list_filename);
 
-		if ((destination[strlen (destination) - 1] == '/')
+		if ((destination[strnlen (destination, BUFSIZ) - 1] == '/')
 		    || (filename[0] == '/'))
 			sprintf (dest_filename, "%s%s", destination, filename);
 		else
@@ -3309,7 +3309,7 @@ get_desired_destination_for_archive (GFile *file)
 		new_name = g_strconcat (name, "_FILES", NULL);
 	else
 		/* ...else use the name without the extension */
-		new_name = g_strndup (name, strlen (name) - strlen (ext));
+		new_name = g_strndup (name, strnlen (name, BUFSIZ) - strnlen (ext, BUFSIZ));
 	new_name_escaped = g_uri_escape_string (new_name, "", FALSE);
 
 	desired_destination = g_strconcat (directory_uri, "/", new_name_escaped, NULL);

--- a/src/fr-command-7z.c
+++ b/src/fr-command-7z.c
@@ -172,7 +172,7 @@ list__process_line (char     *line,
 		fdata->original_path = g_strdup (fields[1]);
 		fdata->full_path = g_strconcat ((fdata->original_path[0] != '/') ? "/" : "",
 						fdata->original_path,
-						(fdata->dir && (fdata->original_path[strlen (fdata->original_path) - 1] != '/')) ? "/" : "",
+						(fdata->dir && (fdata->original_path[strnlen (fdata->original_path, BUFSIZ) - 1] != '/')) ? "/" : "",
 						NULL);
 	}
 	else if (strcmp (fields[0], "Folder") == 0) {
@@ -276,7 +276,7 @@ parse_progress_line (FrCommand  *comm,
 {
 	int prefix_len;
 
-	prefix_len = strlen (prefix);
+	prefix_len = strnlen (prefix, BUFSIZ);
 	if (strncmp (line, prefix, prefix_len) == 0)
 		fr_command_progress (comm, (double) ++comm->n_file / (comm->n_files + 1));
 }

--- a/src/fr-command-alz.c
+++ b/src/fr-command-alz.c
@@ -115,7 +115,7 @@ process_line (char     *line,
 	fdata->size = g_ascii_strtoull (fields[3], NULL, 10);
 
 	name_field = g_strdup (get_last_field (line, 6));
-	name_len = strlen (name_field);
+	name_len = strnlen (name_field, BUFSIZ);
 
 	name_last = name_field[name_len - 1];
 	fdata->dir = name_last == '\\';

--- a/src/fr-command-cpio.c
+++ b/src/fr-command-cpio.c
@@ -143,7 +143,7 @@ list__process_line (char     *line,
 		fdata->original_path = fdata->full_path + 1;
 	}
 
-	if (fdata->dir && (name[strlen (name) - 1] != '/')) {
+	if (fdata->dir && (name[strnlen (name, BUFSIZ) - 1] != '/')) {
 		char *old_full_path = fdata->full_path;
 		fdata->full_path = g_strconcat (old_full_path, "/", NULL);
 		g_free (old_full_path);

--- a/src/fr-command-dpkg.c
+++ b/src/fr-command-dpkg.c
@@ -134,7 +134,7 @@ process_data_line (char     *line,
                 fdata->full_path = g_strconcat ("/", name, NULL);
                 fdata->original_path = fdata->full_path + 1;
         }
-        if (fdata->dir && (name[strlen (name) - 1] != '/')) {
+        if (fdata->dir && (name[strnlen (name, BUFSIZ) - 1] != '/')) {
                 char *old_full_path = fdata->full_path;
                 fdata->full_path = g_strconcat (old_full_path, "/", NULL);
                 g_free (old_full_path);

--- a/src/fr-command-jar.c
+++ b/src/fr-command-jar.c
@@ -71,7 +71,7 @@ fr_command_jar_add (FrCommand     *comm,
 		else if (file_extension_is (filename, ".class"))
 			package = get_package_name_from_class_file (path);
 
-		if ((package == NULL) || (strlen (package) == 0))
+		if ((package == NULL) || (strnlen (package, BUFSIZ) == 0))
 			zip_list = g_list_append (zip_list, g_strdup (filename));
 		else {
 			JarData *newdata = g_new0 (JarData, 1);

--- a/src/fr-command-lha.c
+++ b/src/fr-command-lha.c
@@ -108,22 +108,22 @@ split_line_lha (char *line)
 	if (strncmp (line, "[MS-DOS]", 8) == 0) {
 		fields[i++] = g_strdup ("");
 		fields[i++] = g_strdup ("");
-		line += strlen ("[MS-DOS]");
+		line += strnlen ("[MS-DOS]", BUFSIZ);
 	}
 	else if (strncmp (line, "[generic]", 9) == 0) {
 		fields[i++] = g_strdup ("");
 		fields[i++] = g_strdup ("");
-		line += strlen ("[generic]");
+		line += strnlen ("[generic]", BUFSIZ);
 	}
 	else if (strncmp (line, "[unknown]", 9) == 0) {
 		fields[i++] = g_strdup ("");
 		fields[i++] = g_strdup ("");
-		line += strlen ("[unknown]");
+		line += strnlen ("[unknown]", BUFSIZ);
 	}
 	else if (strncmp (line, "[Amiga]", 7) == 0) {
 		fields[i++] = g_strdup ("");
 		fields[i++] = g_strdup ("");
-		line += strlen ("[Amiga]");
+		line += strnlen ("[Amiga]", BUFSIZ);
 	}
 
 	scan = eat_spaces (line);

--- a/src/fr-command-lrzip.c
+++ b/src/fr-command-lrzip.c
@@ -41,7 +41,7 @@ list__process_line (char     *line,
 
 	g_return_if_fail (line != NULL);
 
-	if (strlen (line) == 0)
+	if (strnlen (line, BUFSIZ) == 0)
 		return;
 
 	if (! g_str_has_prefix (line, "Decompressed file size:"))
@@ -61,7 +61,7 @@ list__process_line (char     *line,
 
 	char *new_fname = g_strdup (file_name_from_path (comm->filename));
 	if (g_str_has_suffix (new_fname, ".lrz"))
-		new_fname[strlen (new_fname) - 4] = '\0';
+		new_fname[strnlen (new_fname, BUFSIZ) - 4] = '\0';
 
 	if (*new_fname == '/') {
 		fdata->full_path = g_strdup (new_fname);

--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -411,7 +411,7 @@ parse_progress_line (FrCommand  *comm,
 		     const char *message_prefix,
 		     const char *line)
 {
-	if (strncmp (line, prefix, strlen (prefix)) == 0)
+	if (strncmp (line, prefix, strnlen (prefix, BUFSIZ)) == 0)
 		fr_command_progress (comm, (double) ++comm->n_file / (comm->n_files + 1));
 }
 
@@ -434,7 +434,7 @@ process_line__add (char     *line,
 			GFile *volume_file;
 
 			volume_filename = g_strdup (archive_filename);
-			volume_filename[strlen (volume_filename) - 5] = '1';
+			volume_filename[strnlen (volume_filename, BUFSIZ) - 5] = '1';
 			volume_file = g_file_new_for_path (volume_filename);
 			fr_command_set_multi_volume (comm, volume_file);
 
@@ -713,7 +713,7 @@ fr_command_rar_handle_error (FrCommand   *comm,
 			g_clear_error (&error->gerror);
 
 			error->type = FR_PROC_ERROR_MISSING_VOLUME;
-			volume_filename = g_path_get_basename (line + strlen ("Cannot find volume "));
+			volume_filename = g_path_get_basename (line + strnlen ("Cannot find volume ", BUFSIZ));
 			error->gerror = g_error_new (FR_ERROR, error->status, _("Could not find the volume: %s"), volume_filename);
 			g_free (volume_filename);
 			break;

--- a/src/fr-command-rpm.c
+++ b/src/fr-command-rpm.c
@@ -151,7 +151,7 @@ list__process_line (char     *line,
 		fdata->full_path = g_strconcat ("/", name, NULL);
 		fdata->original_path = fdata->full_path + 1;
 	}
-	if (fdata->dir && (name[strlen (name) - 1] != '/')) {
+	if (fdata->dir && (name[strnlen (name, BUFSIZ) - 1] != '/')) {
 		char *old_full_path = fdata->full_path;
 		fdata->full_path = g_strconcat (old_full_path, "/", NULL);
 		g_free (old_full_path);

--- a/src/fr-command-tar.c
+++ b/src/fr-command-tar.c
@@ -296,7 +296,7 @@ process_line__generic (char     *line,
 	if (line == NULL)
 		return;
 
-	if (line[strlen (line) - 1] == '/') /* ignore directories */
+	if (line[strnlen (line, BUFSIZ) - 1] == '/') /* ignore directories */
 		return;
 
 	if (comm->n_files != 0) {
@@ -767,7 +767,7 @@ get_uncompressed_name (FrCommandTar *c_tar,
 {
 	FrCommand *comm = FR_COMMAND (c_tar);
 	char      *new_name = g_strdup (e_filename);
-	int        l = strlen (new_name);
+	int        l = strnlen (new_name, BUFSIZ);
 
 	if (is_mime_type (comm->mime_type, "application/x-compressed-tar")) {
 		/* X.tgz     -->  X.tar

--- a/src/fr-command-unstuff.c
+++ b/src/fr-command-unstuff.c
@@ -91,13 +91,13 @@ unstuff_is_shit_with_filenames (const char *orig)
 	g_free (current_dir);
 
 	/* 3 characters for each ../ plus filename length plus \0 */
-	filename = g_malloc (3 * i + strlen (orig) + 1);
+	filename = g_malloc (3 * i + strnlen (orig, BUFSIZ) + 1);
 	i = 0;
 	for ( ; num_slashes > 0 ; num_slashes--) {
 		memcpy (filename + i, "../", 3);
 		i+=3;
 	}
-	memcpy (filename + i, orig, strlen (orig) + 1);
+	memcpy (filename + i, orig, strnlen (orig, BUFSIZ) + 1);
 
 	return filename;
 }
@@ -121,7 +121,7 @@ process_line (char     *line,
 		guint size;
 
 		ssize = strstr (line, "progressEvent - ")
-			+ strlen ("progressEvent - ");
+			+ strnlen ("progressEvent - ", BUFSIZ);
 		if (ssize[0] == '\0')
 			size = 0;
 		else
@@ -140,7 +140,7 @@ process_line (char     *line,
 
 	/* Look for the filename, ends with a comma */
 	str_start = strstr (line, unstuff_comm->target_dir + 1);
-	str_start = str_start + strlen (unstuff_comm->target_dir) - 1;
+	str_start = str_start + strnlen (unstuff_comm->target_dir, BUFSIZ) - 1;
 	if (str_start[0] != '/')
 		str_start--;
 	if (str_start[0] == '.')

--- a/src/fr-command-zip.c
+++ b/src/fr-command-zip.c
@@ -109,7 +109,7 @@ list__process_line (char     *line,
 	if (FR_COMMAND_ZIP (comm)->is_empty)
 		return;
 
-	line_l = strlen (line);
+	line_l = strnlen (line, BUFSIZ);
 
 	if (line_l == 0)
 		return;

--- a/src/fr-process.c
+++ b/src/fr-process.c
@@ -691,10 +691,10 @@ start_current_command (FrProcess *process)
 		if (g_str_has_prefix (commandline->str, "mv")) {
 
 			if ((i == 3) && (!g_file_test (argv[2], G_FILE_TEST_EXISTS)) && (!fixname)) {
-				char rarfile[strlen (argv[2]) + 7];
+				char rarfile[strnlen (argv[2], BUFSIZ) + 7];
 
 				g_strlcpy (rarfile, argv[2], sizeof (rarfile));
-				rarfile[strlen (rarfile) - 3] = 0;
+				rarfile[strnlen (rarfile, BUFSIZ) - 3] = 0;
 				g_strlcat (rarfile, "part1.rar", sizeof (rarfile));
 
 				if (g_str_has_suffix (argv[2], ".7z")) {
@@ -708,7 +708,7 @@ start_current_command (FrProcess *process)
 					fixname = TRUE;
 				}
 				else if (g_str_has_suffix (argv[2], ".rar")) {
-					rarfile[strlen(rarfile) - 5] = 0;
+					rarfile[strnlen(rarfile, BUFSIZ) - 5] = 0;
 					g_string_append (commandline, " ");
 
 					gchar *tempstr = g_shell_quote (rarfile);

--- a/src/gio-utils.c
+++ b/src/gio-utils.c
@@ -20,6 +20,7 @@
  *  Foundation, Inc., 59 Temple Street #330, Boston, MA 02110-1301, USA.
  */
 
+#include <stdio.h>
 #include <string.h>
 #include <glib.h>
 #include <gio/gio.h>
@@ -102,7 +103,7 @@ filter_matches (Filter     *filter,
 		return FALSE;
 
 	if ((filter->options & FILTER_NOBACKUPFILES)
-	    && (file_name[strlen (file_name) - 1] == '~'))
+	    && (file_name[strnlen (file_name, BUFSIZ) - 1] == '~'))
 		return FALSE;
 
 	if (filter->pattern == NULL)
@@ -526,13 +527,13 @@ get_dir_list_from_file_list (GHashTable *h_dirs,
 
 	if (base_dir == NULL)
 		base_dir = "";
-	base_dir_len = strlen (base_dir);
+	base_dir_len = strnlen (base_dir, BUFSIZ);
 
 	for (scan = files; scan; scan = scan->next) {
 		char *filename = scan->data;
 		char *dir_name;
 
-		if (strlen (filename) <= base_dir_len)
+		if (strnlen (filename, BUFSIZ) <= base_dir_len)
 			continue;
 
 		if (is_dir_list)
@@ -825,7 +826,7 @@ g_list_items_async (GList             *items,
 
 	base_len = 0;
 	if (strcmp (base_dir, "/") != 0)
-		base_len = strlen (base_dir);
+		base_len = strnlen (base_dir, BUFSIZ);
 
 	for (scan = items; scan; scan = scan->next) {
 		char *uri = scan->data;

--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -119,7 +119,7 @@ static int
 count_chars_to_escape (const char *str,
 		       const char *meta_chars)
 {
-	int         meta_chars_n = strlen (meta_chars);
+	int         meta_chars_n = strnlen (meta_chars, BUFSIZ);
 	const char *s;
 	int         n = 0;
 
@@ -141,7 +141,7 @@ escape_str_common (const char *str,
 		   const char  prefix,
 		   const char  postfix)
 {
-	int         meta_chars_n = strlen (meta_chars);
+	int         meta_chars_n = strnlen (meta_chars, BUFSIZ);
 	char       *escaped;
 	int         i, new_l, extra_chars = 0;
 	const char *s;
@@ -155,7 +155,7 @@ escape_str_common (const char *str,
 	if (postfix)
 		extra_chars++;
 
-	new_l = strlen (str) + (count_chars_to_escape (str, meta_chars) * extra_chars);
+	new_l = strnlen (str, BUFSIZ) + (count_chars_to_escape (str, meta_chars) * extra_chars);
 	escaped = g_malloc (new_l + 1);
 
 	s = str;
@@ -200,7 +200,7 @@ g_utf8_strstr (const char *haystack, const char *needle)
 	gsize       i;
 	gsize       haystack_len = g_utf8_strlen (haystack, -1);
 	gsize       needle_len = g_utf8_strlen (needle, -1);
-	int         needle_size = strlen (needle);
+	int         needle_size = strnlen (needle, BUFSIZ);
 
 	s = haystack;
 	for (i = 0; i <= haystack_len - needle_len; i++) {
@@ -234,7 +234,7 @@ g_utf8_strsplit (const char *string,
 	remainder = string;
 	s = g_utf8_strstr (remainder, delimiter);
 	if (s != NULL) {
-		gsize delimiter_size = strlen (delimiter);
+		gsize delimiter_size = strnlen (delimiter, BUFSIZ);
 
 		while (--max_tokens && (s != NULL)) {
 			gsize  size = s - remainder;
@@ -282,7 +282,7 @@ g_utf8_strchug (char *string)
 		c = g_utf8_get_char (scan);
 	}
 
-	g_memmove (string, scan, strlen (scan) + 1);
+	g_memmove (string, scan, strnlen (scan, BUFSIZ) + 1);
 
 	return string;
 }
@@ -412,7 +412,7 @@ _g_strdup_with_max_size (const char *s,
 			 int         max_size)
 {
 	char *result;
-	int   l = strlen (s);
+	int   l = strnlen (s, BUFSIZ);
 
 	if (l > max_size) {
 		char *first_half;
@@ -726,7 +726,7 @@ _g_path_get_file_name (const gchar *file_name)
 	if (file_name[0] == '\0')
 		return "";
 
-	last_char = strlen (file_name) - 1;
+	last_char = strnlen (file_name, BUFSIZ) - 1;
 
 	if (file_name [last_char] == G_DIR_SEPARATOR)
 		return "";
@@ -750,8 +750,8 @@ _g_path_get_base_name (const char *path,
 	if (junk_paths)
 		return _g_path_get_file_name (path);
 
-	base_dir_len = strlen (base_dir);
-	if (strlen (path) < base_dir_len)
+	base_dir_len = strnlen (base_dir, BUFSIZ);
+	if (strnlen (path, BUFSIZ) < base_dir_len)
 		return NULL;
 
 	base_path = path + base_dir_len;

--- a/src/main.c
+++ b/src/main.c
@@ -115,7 +115,7 @@ fr_restore_session (EggSMClient *client)
 
 		window = fr_window_new ();
 		gtk_widget_show (window);
-		if (strlen (archive))
+		if (strnlen (archive, BUFSIZ))
 			fr_window_archive_open (FR_WINDOW (window), archive, GTK_WINDOW (window));
 
 		g_free (archive);

--- a/src/mkdtemp.c
+++ b/src/mkdtemp.c
@@ -126,7 +126,7 @@ gen_tempname (tmpl)
   int count, fd = -1;
   int save_errno = errno;
 
-  len = strlen (tmpl);
+  len = strnlen (tmpl, BUFSIZ);
   if (len < 6 || strcmp (&tmpl[len - 6], "XXXXXX"))
     {
       __set_errno (EINVAL);

--- a/src/rar-utils.c
+++ b/src/rar-utils.c
@@ -49,7 +49,7 @@ get_first_volume_name (const char           *name,
 		int    l, i;
 
 		parts = g_regex_split (re, name, 0);
-		l = strlen (parts[2]);
+		l = strnlen (parts[2], BUFSIZ);
 		switch (extension_type) {
 		case FIRST_VOLUME_IS_000:
 			for (i = 0; i < l; i++)


### PR DESCRIPTION
Fixes `flawfinder` warnings:

`(buffer) strlen: Does not handle strings that are not \0-terminated; if given one it may perform an over-read (it could cause a crash if unprotected) (CWE-126).`

https://dwheeler.com/flawfinder

http://cwe.mitre.org/data/definitions/126.html