### PR TITLE
Help: replace link linkend with xref linkend

### DIFF
--- a/help/C/index.docbook
+++ b/help/C/index.docbook
@@ -1132,7 +1132,7 @@
 
   <section xml:id="engrampa-view-type"><info><title>To Set the View Type</title></info>
     
-    <para>If the archive contains folders, you can show the archive contents in either <link linkend="engrampa-view-type-folder">folder view</link> or <link linkend="engrampa-view-type-file">file view</link>. 
+    <para>If the archive contains folders, you can show the archive contents in either <xref linkend="engrampa-view-type-folder"/> or <xref linkend="engrampa-view-type-file"/>.
     </para>
 
     <section xml:id="engrampa-view-type-folder"><info><title>Folder View</title></info>


### PR DESCRIPTION
Yelp viewer can't open cross-references to other parts of
the manual using link linkend.