### PR TITLE
fr-command-unarchiver: ask password if required

### DIFF
--- a/src/fr-command-unarchiver.c
+++ b/src/fr-command-unarchiver.c
@@ -237,12 +237,16 @@ fr_command_unarchiver_handle_error (FrCommand   *comm,
 	if (error->type == FR_PROC_ERROR_NONE)
 		return;
 
-	for (scan = g_list_last (comm->process->err.raw); scan; scan = scan->prev) {
-		char *line = scan->data;
+	if (error->type == FR_PROC_ERROR_COMMAND_ERROR) {
+		for (scan = g_list_last (comm->process->out.raw); scan; scan = scan->prev) {
+			char *line = scan->data;
 
-		if (strstr (line, "password") != NULL) {
-			error->type = FR_PROC_ERROR_ASK_PASSWORD;
-			break;
+			if ((strstr (line, "This archive requires a password to unpack.") != NULL)  ||
+			    (strstr (line, "Failed! (Missing or wrong password)") != NULL)) { 
+
+				error->type = FR_PROC_ERROR_ASK_PASSWORD;
+				break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
without this PR:

![2019-07-13_16-58](https://user-images.githubusercontent.com/7734191/61173156-ae054c80-a58f-11e9-9f01-156172ed2b60.png)

with this PR:

![2019-07-13_16-57](https://user-images.githubusercontent.com/7734191/61173158-b493c400-a58f-11e9-8763-8108d369032a.png)

file to test (inside the .zip): [testing.zip](https://github.com/mate-desktop/engrampa/files/3388907/testing.zip) password 123

In the tests, make sure the packages `rar` and `unrar` aren't installed, and make sure the package `unar` is installed.