### PR TITLE
fr-command-lrzip: Fix empty string check

### DIFF
--- a/src/fr-command-lrzip.c
+++ b/src/fr-command-lrzip.c
@@ -76,7 +76,7 @@ list__process_line (char     *line,
 	fdata->dir = FALSE;
 	fdata->link = NULL;
 
-	if (fdata->name == 0)
+	if (*fdata->name == '\0')
 		file_data_free (fdata);
 	else
 		fr_command_add_file (comm, fdata);


### PR DESCRIPTION
str is empty: if (*str == '\0') {...}