### PR TITLE
comparison of integers of different signs: 'int' and 'guint'

### DIFF
--- a/src/dlg-prop.c
+++ b/src/dlg-prop.c
@@ -157,7 +157,7 @@ dlg_prop (FrWindow *window)
 
 	uncompressed_size = 0;
 	if (fr_window_archive_is_present (window)) {
-		int i;
+		guint i;
 
 		for (i = 0; i < window->archive->command->files->len; i++) {
 			FileData *fd = g_ptr_array_index (window->archive->command->files, i);

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -2517,7 +2517,7 @@ delete_from_archive (FrArchive *archive,
 	/* file_list == NULL means delete all the files in the archive. */
 
 	if (file_list == NULL) {
-		int i;
+		guint i;
 
 		for (i = 0; i < archive->command->files->len; i++) {
 			FileData *fdata = g_ptr_array_index (archive->command->files, i);
@@ -3073,7 +3073,7 @@ fr_archive_extract_to_local (FrArchive  *archive,
 
 	extract_all = (file_list == NULL);
 	if (extract_all && (! all_options_supported || ! archive->command->propCanExtractAll)) {
-		int i;
+		guint i;
 
 		file_list = NULL;
 		for (i = 0; i < archive->command->files->len; i++) {
@@ -3126,7 +3126,7 @@ fr_archive_extract_to_local (FrArchive  *archive,
 				 && ! archive->command->propExtractCanJunkPaths)));
 
 	if (extract_all && ! file_list_created) {
-		int i;
+		guint i;
 
 		file_list = NULL;
 		for (i = 0; i < archive->command->files->len; i++) {

--- a/src/fr-command-unarchiver.c
+++ b/src/fr-command-unarchiver.c
@@ -83,7 +83,7 @@ list_command_completed (gpointer data)
 
 		if (json_object_get_int_member (root, "lsarFormatVersion") == LSAR_SUPPORTED_FORMAT) {
 			JsonArray *content;
-			int        i;
+			guint      i;
 
 			content = json_object_get_array_member (root, "lsarContents");
 			for (i = 0; i < json_array_get_length (content); i++) {

--- a/src/fr-init.c
+++ b/src/fr-init.c
@@ -289,7 +289,7 @@ static FrCommandCaps
 fr_registered_command_get_capabilities (FrRegisteredCommand *reg_com,
 				        const char          *mime_type)
 {
-	int i;
+	guint i;
 
 	for (i = 0; i < reg_com->caps->len; i++) {
 		FrMimeTypeCap *cap;
@@ -307,7 +307,7 @@ static FrCommandCaps
 fr_registered_command_get_potential_capabilities (FrRegisteredCommand *reg_com,
 						  const char          *mime_type)
 {
-	int i;
+	guint i;
 
 	if (mime_type == NULL)
 		return FR_COMMAND_CAN_DO_NOTHING;
@@ -336,7 +336,7 @@ register_command (GType command_type)
 G_GNUC_UNUSED static gboolean
 unregister_command (GType command_type)
 {
-	int i;
+	guint i;
 
 	for (i = 0; i < Registered_Commands->len; i++) {
 		FrRegisteredCommand *command;
@@ -390,7 +390,7 @@ GType
 get_command_type_from_mime_type (const char    *mime_type,
 				 FrCommandCaps  requested_capabilities)
 {
-	int i;
+	guint i;
 
 	if (mime_type == NULL)
 		return 0;
@@ -415,7 +415,7 @@ GType
 get_preferred_command_for_mime_type (const char    *mime_type,
 				     FrCommandCaps  requested_capabilities)
 {
-	int i;
+	guint i;
 
 	for (i = 0; i < Registered_Commands->len; i++) {
 		FrRegisteredCommand *command;
@@ -436,14 +436,14 @@ get_preferred_command_for_mime_type (const char    *mime_type,
 void
 update_registered_commands_capabilities (void)
 {
-	int i;
+	guint i;
 
 	g_hash_table_remove_all (ProgramsCache);
 
 	for (i = 0; i < Registered_Commands->len; i++) {
 		FrRegisteredCommand *reg_com;
 		FrCommand           *command;
-		int                  j;
+		guint                j;
 
 		reg_com = g_ptr_array_index (Registered_Commands, i);
 		command = (FrCommand*) g_object_new (reg_com->type, NULL);
@@ -582,11 +582,11 @@ static void
 compute_supported_archive_types (void)
 {
 	int sf_i = 0, s_i = 0, o_i = 0, c_i = 0;
-	int i;
+	guint i;
 
 	for (i = 0; i < Registered_Commands->len; i++) {
 		FrRegisteredCommand *reg_com;
-		int                  j;
+		guint                j;
 
 		reg_com = g_ptr_array_index (Registered_Commands, i);
 		for (j = 0; j < reg_com->caps->len; j++) {

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -930,7 +930,7 @@ static GPtrArray *
 fr_window_get_current_dir_list (FrWindow *window)
 {
 	GPtrArray *files;
-	int        i;
+	guint      i;
 
 	files = g_ptr_array_sized_new (128);
 
@@ -1082,7 +1082,7 @@ get_dir_size (FrWindow   *window,
 	guint64  size;
 	char    *dirname;
 	int      dirname_l;
-	int      i;
+	guint    i;
 
 	dirname = g_strconcat (current_dir, name, "/", NULL);
 	dirname_l = strlen (dirname);
@@ -1184,7 +1184,7 @@ fr_window_compute_list_names (FrWindow  *window,
 	const char *current_dir;
 	int         current_dir_len;
 	GHashTable *names_hash;
-	int         i;
+	guint       i;
 	gboolean    visible_list_started = FALSE;
 	gboolean    visible_list_completed = FALSE;
 	gboolean    different_name;
@@ -1223,7 +1223,7 @@ fr_window_dir_exists_in_archive (FrWindow   *window,
 				 const char *dir_name)
 {
 	int dir_name_len;
-	int i;
+	guint i;
 
 	if (dir_name == NULL)
 		return FALSE;
@@ -1499,7 +1499,7 @@ fr_window_update_statusbar_list_info (FrWindow *window)
 
 	if (window->priv->archive_present) {
 		GPtrArray *files = fr_window_get_current_dir_list (window);
-		int        i;
+		guint i;
 
 		for (i = 0; i < files->len; i++) {
 			FileData *fd = g_ptr_array_index (files, i);
@@ -1561,7 +1561,7 @@ static void
 fr_window_populate_file_list (FrWindow  *window,
 			      GPtrArray *files)
 {
-	int i;
+	guint i;
 
 	gtk_list_store_clear (window->priv->list_store);
 
@@ -1770,7 +1770,7 @@ fr_window_update_dir_tree (FrWindow *window)
 {
 	GPtrArray  *dirs;
 	GHashTable *dir_cache;
-	int         i;
+	guint       i;
 	GdkPixbuf  *icon;
 
 	gtk_tree_store_clear (window->priv->tree_store);
@@ -3388,7 +3388,7 @@ get_dir_list_from_path (FrWindow *window,
 	char  *dirname;
 	int    dirname_l;
 	GList *list = NULL;
-	int    i;
+	guint  i;
 
 	if (path[strlen (path) - 1] != '/')
 		dirname = g_strconcat (path, "/", NULL);
@@ -3591,7 +3591,7 @@ fr_window_get_file_list_pattern (FrWindow    *window,
 {
 	GRegex **regexps;
 	GList   *list;
-	int      i;
+	guint    i;
 
 	g_return_val_if_fail (window != NULL, NULL);
 
@@ -3621,7 +3621,7 @@ static GList *
 fr_window_get_file_list (FrWindow *window)
 {
 	GList *list;
-	int    i;
+	guint  i;
 
 	g_return_val_if_fail (window != NULL, NULL);
 
@@ -6666,7 +6666,7 @@ archive_is_encrypted (FrWindow *window,
 	gboolean encrypted = FALSE;
 
 	if (file_list == NULL) {
-		int i;
+		guint i;
 
 		for (i = 0; ! encrypted && i < window->archive->command->files->len; i++) {
 			FileData *fdata = g_ptr_array_index (window->archive->command->files, i);
@@ -6678,7 +6678,7 @@ archive_is_encrypted (FrWindow *window,
 	else {
 
 		GHashTable *file_hash;
-		int         i;
+		guint       i;
 		GList      *scan;
 
 		file_hash = g_hash_table_new (g_str_hash, g_str_equal);
@@ -7751,7 +7751,7 @@ name_is_present (FrWindow    *window,
 		 char       **reason)
 {
 	gboolean  retval = FALSE;
-	int       i;
+	guint     i;
 	char     *new_filename;
 	int       new_filename_l;
 

--- a/src/java-utils.c
+++ b/src/java-utils.c
@@ -252,7 +252,7 @@ get_package_name_from_class_file (char *fname)
 	guint16        length = 0, end = 0, utf_index = 0;
 	guint32        magic;
 	guint16        major, minor, count;
-	int            i = 0;
+	guint          i = 0;
 
 	if (! g_file_test (fname, G_FILE_TEST_EXISTS))
 		return NULL;


### PR DESCRIPTION
Fix compiler warning:
comparison of integers of different signs: 'int' and 'guint' (aka 'unsigned int') [-Wsign-compare]