### PR TITLE
java-utils: Remove blank spaces before reading package name

### DIFF
--- a/src/java-utils.c
+++ b/src/java-utils.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <ctype.h>
 #include <glib.h>
 #include "java-utils.h"
 
@@ -423,13 +424,23 @@ get_package_name_from_java_file (char *fname)
 			int  index = 0;
 
 			while (read (cfile->fd, &ch, 1) == 1) {
+				if ((ch != ' ') && (ch != '\t'))
+					break;
+			}
+			do {
 				if (ch == ';')
 					break;
-				if (ch == '.')
+				if (ch == '.') {
 					buffer[index++] = '/';
-				else
+				} else if (isalnum (ch) != 0) {
 					buffer[index++] = ch;
-			}
+				} else if ((ch == '_') || (ch == '$')) {
+					buffer[index++] = ch;
+				} else {
+					index = 0;
+					break;
+				}
+			} while (read (cfile->fd, &ch, 1) == 1);
 			buffer[index] = 0;
 			package = g_strdup (buffer);
 		}


### PR DESCRIPTION
Closes https://github.com/mate-desktop/engrampa/issues/291

Test:
```
touch test.txt
zip test.zip test.txt
mv test.zip test.jar
cat << EOF > HelloWorld.java
package org.mate.tests;

class HelloWorld
{
    public static void main(String args[])
    {
        System.out.println("Hello, World");
    }
}
EOF
engrampa -a test.jar HelloWorld.java
jar tf ~/test.jar
```
Output:
```
test.txt
org/mate/tests/HelloWorld.java
```