### PR TITLE
remove build warning: local variable shadows another variable

### DIFF
--- a/caja/caja-engrampa.c
+++ b/caja/caja-engrampa.c
@@ -39,26 +39,21 @@ extract_to_callback (CajaMenuItem *item,
 		     gpointer          user_data)
 {
 	GList            *files, *scan;
-	CajaFileInfo *file;
 	char             *default_dir;
 	char             *quoted_default_dir;
 	GString          *cmd;
 
 	files = g_object_get_data (G_OBJECT (item), "files");
-	file = files->data;
-
-	default_dir = caja_file_info_get_parent_uri (file);
-
+	default_dir = caja_file_info_get_parent_uri (files->data);
 	quoted_default_dir = g_shell_quote (default_dir);
 
 	cmd = g_string_new ("engrampa");
 	g_string_append_printf(cmd," --default-dir=%s --extract", quoted_default_dir);
 
 	for (scan = files; scan; scan = scan->next) {
-		CajaFileInfo *file = scan->data;
-		char             *uri, *quoted_uri;
+		char *uri, *quoted_uri;
 
-		uri = caja_file_info_get_uri (file);
+		uri = caja_file_info_get_uri (scan->data);
 		quoted_uri = g_shell_quote (uri);
 		g_string_append_printf (cmd, " %s", quoted_uri);
 		g_free (uri);
@@ -114,15 +109,12 @@ add_callback (CajaMenuItem *item,
 	      gpointer          user_data)
 {
 	GList            *files, *scan;
-	CajaFileInfo *file;
 	char             *uri, *dir;
 	char             *quoted_uri, *quoted_dir;
 	GString          *cmd;
 
 	files = g_object_get_data (G_OBJECT (item), "files");
-	file = files->data;
-
-	uri = caja_file_info_get_uri (file);
+	uri = caja_file_info_get_uri (files->data);
 	dir = g_path_get_dirname (uri);
 	quoted_dir = g_shell_quote (dir);
 
@@ -134,9 +126,7 @@ add_callback (CajaMenuItem *item,
 	g_free (quoted_dir);
 
 	for (scan = files; scan; scan = scan->next) {
-		CajaFileInfo *file = scan->data;
-
-		uri = caja_file_info_get_uri (file);
+		uri = caja_file_info_get_uri (scan->data);
 		quoted_uri = g_shell_quote (uri);
 		g_string_append_printf (cmd, " %s", quoted_uri);
 		g_free (uri);

--- a/src/actions.c
+++ b/src/actions.c
@@ -224,9 +224,9 @@ get_archive_filename_from_selector (DlgNewData *data)
     debug (DEBUG_INFO, "create/save %s\n", uri);
 
     if (uri_exists (uri)) {
-        GtkWidget *dialog;
 
         if (! is_supported_extension (data->dialog, uri, data->supported_types)) {
+            GtkWidget *dialog;
             dialog = _gtk_error_dialog_new (GTK_WINDOW (data->dialog),
                             GTK_DIALOG_MODAL,
                             NULL,

--- a/src/dlg-add-files.c
+++ b/src/dlg-add-files.c
@@ -116,10 +116,8 @@ file_sel_response_cb (GtkWidget      *widget,
 	/**/
 
 	selections = gtk_file_chooser_get_uris (file_sel);
-	for (iter = selections; iter != NULL; iter = iter->next) {
-		char *uri = iter->data;
-		item_list = g_list_prepend (item_list, g_file_new_for_uri (uri));
-	}
+	for (iter = selections; iter != NULL; iter = iter->next)
+		item_list = g_list_prepend (item_list, g_file_new_for_uri (iter->data));
 
 	if (item_list != NULL)
 		fr_window_archive_add_files (window, item_list, update);

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -4932,7 +4932,7 @@ add_file_list_columns (FrWindow    *window,
 	/* Other columns */
 
 	for (j = 0, i = COLUMN_SIZE; i < NUMBER_OF_COLUMNS; i++, j++) {
-		GValue  value = { 0, };
+		GValue  value_oc = { 0, };
 
 		renderer = gtk_cell_renderer_text_new ();
 		column = gtk_tree_view_column_new_with_attributes (g_dpgettext2 (NULL, "File", titles[j]),
@@ -4946,10 +4946,10 @@ add_file_list_columns (FrWindow    *window,
 
 		gtk_tree_view_column_set_sort_column_id (column, i);
 
-		g_value_init (&value, PANGO_TYPE_ELLIPSIZE_MODE);
-		g_value_set_enum (&value, PANGO_ELLIPSIZE_END);
-		g_object_set_property (G_OBJECT (renderer), "ellipsize", &value);
-		g_value_unset (&value);
+		g_value_init (&value_oc, PANGO_TYPE_ELLIPSIZE_MODE);
+		g_value_set_enum (&value_oc, PANGO_ELLIPSIZE_END);
+		g_object_set_property (G_OBJECT (renderer), "ellipsize", &value_oc);
+		g_value_unset (&value_oc);
 
 		gtk_tree_view_append_column (treeview, column);
 	}


### PR DESCRIPTION
actions.c:245:24: warning: declaration of ‘dialog’ shadows a previous local [-Wshadow]
caja-engrampa.c:137:17: warning: declaration of ‘file’ shadows a previous local [-Wshadow]
caja-engrampa.c:58:17: warning: declaration of ‘file’ shadows a previous local [-Wshadow]
dlg-add-files.c:120:9: warning: declaration of ‘uri’ shadows a previous local [-Wshadow]
fr-window.c:4935:11: warning: declaration of ‘value’ shadows a previous local [-Wshadow]

Test:
```bash
#!/bin/bash
CFLAGS="-g -O -D_FORTIFY_SOURCE=2 -Wall -Wextra -Wendif-labels -Wformat=2 -Winit-self -Wswitch-enum -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-align -Wwrite-strings -Wjump-misses-init -Wlogical-op -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Wnested-externs -Wundef -Wformat-security" ./autogen.sh --prefix=/usr
make clean &> /dev/null
make 2> report.txt
for warning in $(grep warning report.txt | grep -Po '\[\-W.*\]' | sed 's/[][]//g' | sort -u)
do
 type=${warning#"-W"}
 num=$(echo "grep $type report.txt | wc -l" | sh)
 echo "$warning $num"
done
```
Output:
```shell
$ ./build.sh
...
-Wbad-function-cast 2
-Wcast-function-type 65
-Wdeprecated-declarations 58
-Wdiscarded-qualifiers 351
-Wformat-nonliteral 1
-Wmissing-field-initializers 33
-Wmissing-prototypes 4
-Wredundant-decls 42
-Wsign-compare 8
-Wswitch-enum 77
-Wtype-limits 1
-Wundef 2
-Wunused-function 1
-Wunused-parameter 495
```