### PR TITLE
Missing initializer for struct field

### DIFF
--- a/caja/caja-engrampa.c
+++ b/caja/caja-engrampa.c
@@ -436,6 +436,7 @@ caja_fr_register_type (GTypeModule *module)
 		sizeof (CajaFr),
 		0,
 		(GInstanceInitFunc) caja_fr_instance_init,
+		NULL
 	};
 
 	static const GInterfaceInfo menu_provider_iface_info = {

--- a/src/eggtreemultidnd.c
+++ b/src/eggtreemultidnd.c
@@ -66,6 +66,7 @@ egg_tree_multi_drag_source_get_type (void)
 	  NULL,		/* class_data */
 	  0,
 	  0,            /* n_preallocs */
+	  NULL,
 	  NULL
 	};
 

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -203,7 +203,8 @@ fr_archive_get_type (void)
 			NULL,
 			sizeof (FrArchive),
 			0,
-			(GInstanceInitFunc) fr_archive_init
+			(GInstanceInitFunc) fr_archive_init,
+			NULL
 		};
 
 		type = g_type_register_static (G_TYPE_OBJECT,

--- a/src/fr-command-7z.c
+++ b/src/fr-command-7z.c
@@ -746,7 +746,8 @@ fr_command_7z_get_type ()
 			NULL,
 			sizeof (FrCommand7z),
 			0,
-			(GInstanceInitFunc) fr_command_7z_init
+			(GInstanceInitFunc) fr_command_7z_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-ace.c
+++ b/src/fr-command-ace.c
@@ -330,7 +330,8 @@ fr_command_ace_get_type ()
 			NULL,
 			sizeof (FrCommandAce),
 			0,
-			(GInstanceInitFunc) fr_command_ace_init
+			(GInstanceInitFunc) fr_command_ace_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-alz.c
+++ b/src/fr-command-alz.c
@@ -393,7 +393,8 @@ fr_command_alz_get_type ()
 			NULL,
 			sizeof (FrCommandAlz),
 			0,
-			(GInstanceInitFunc) fr_command_alz_init
+			(GInstanceInitFunc) fr_command_alz_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-ar.c
+++ b/src/fr-command-ar.c
@@ -379,7 +379,8 @@ fr_command_ar_get_type ()
 			NULL,
 			sizeof (FrCommandAr),
 			0,
-			(GInstanceInitFunc) fr_command_ar_init
+			(GInstanceInitFunc) fr_command_ar_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-arj.c
+++ b/src/fr-command-arj.c
@@ -425,7 +425,8 @@ fr_command_arj_get_type ()
 			NULL,
 			sizeof (FrCommandArj),
 			0,
-			(GInstanceInitFunc) fr_command_arj_init
+			(GInstanceInitFunc) fr_command_arj_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-cfile.c
+++ b/src/fr-command-cfile.c
@@ -688,7 +688,8 @@ fr_command_cfile_get_type ()
 			NULL,
 			sizeof (FrCommandCFile),
 			0,
-			(GInstanceInitFunc) fr_command_cfile_init
+			(GInstanceInitFunc) fr_command_cfile_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-cpio.c
+++ b/src/fr-command-cpio.c
@@ -315,7 +315,8 @@ fr_command_cpio_get_type ()
 			NULL,
 			sizeof (FrCommandCpio),
 			0,
-			(GInstanceInitFunc) fr_command_cpio_init
+			(GInstanceInitFunc) fr_command_cpio_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-dpkg.c
+++ b/src/fr-command-dpkg.c
@@ -301,7 +301,8 @@ fr_command_dpkg_get_type ()
                         NULL,
                         sizeof (FrCommandDpkg),
                         0,
-                        (GInstanceInitFunc) fr_command_dpkg_init
+                        (GInstanceInitFunc) fr_command_dpkg_init,
+			NULL
                 };
 
                 type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-iso.c
+++ b/src/fr-command-iso.c
@@ -304,7 +304,8 @@ fr_command_iso_get_type ()
 			NULL,
 			sizeof (FrCommandIso),
 			0,
-			(GInstanceInitFunc) fr_command_iso_init
+			(GInstanceInitFunc) fr_command_iso_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-jar.c
+++ b/src/fr-command-jar.c
@@ -230,7 +230,8 @@ fr_command_jar_get_type ()
 			NULL,
 			sizeof (FrCommandJar),
 			0,
-			(GInstanceInitFunc) fr_command_jar_init
+			(GInstanceInitFunc) fr_command_jar_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND_ZIP,

--- a/src/fr-command-lha.c
+++ b/src/fr-command-lha.c
@@ -404,7 +404,8 @@ fr_command_lha_get_type ()
 			NULL,
 			sizeof (FrCommandLha),
 			0,
-			(GInstanceInitFunc) fr_command_lha_init
+			(GInstanceInitFunc) fr_command_lha_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-lrzip.c
+++ b/src/fr-command-lrzip.c
@@ -258,7 +258,8 @@ fr_command_lrzip_get_type ()
 			NULL,
 			sizeof (FrCommandLrzip),
 			0,
-			(GInstanceInitFunc) fr_command_lrzip_init
+			(GInstanceInitFunc) fr_command_lrzip_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -828,7 +828,8 @@ fr_command_rar_get_type ()
 			NULL,
 			sizeof (FrCommandRar),
 			0,
-			(GInstanceInitFunc) fr_command_rar_init
+			(GInstanceInitFunc) fr_command_rar_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-rpm.c
+++ b/src/fr-command-rpm.c
@@ -315,7 +315,8 @@ fr_command_rpm_get_type ()
 			NULL,
 			sizeof (FrCommandRpm),
 			0,
-			(GInstanceInitFunc) fr_command_rpm_init
+			(GInstanceInitFunc) fr_command_rpm_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-tar.c
+++ b/src/fr-command-tar.c
@@ -1263,7 +1263,8 @@ fr_command_tar_get_type ()
 			NULL,
 			sizeof (FrCommandTar),
 			0,
-			(GInstanceInitFunc) fr_command_tar_init
+			(GInstanceInitFunc) fr_command_tar_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-unarchiver.c
+++ b/src/fr-command-unarchiver.c
@@ -357,7 +357,8 @@ fr_command_unarchiver_get_type ()
 			NULL,
 			sizeof (FrCommandUnarchiver),
 			0,
-			(GInstanceInitFunc) fr_command_unarchiver_init
+			(GInstanceInitFunc) fr_command_unarchiver_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-unstuff.c
+++ b/src/fr-command-unstuff.c
@@ -377,7 +377,8 @@ fr_command_unstuff_get_type ()
 			NULL,
 			sizeof (FrCommandUnstuff),
 			0,
-			(GInstanceInitFunc) fr_command_unstuff_init
+			(GInstanceInitFunc) fr_command_unstuff_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-zip.c
+++ b/src/fr-command-zip.c
@@ -509,7 +509,8 @@ fr_command_zip_get_type ()
 			NULL,
 			sizeof (FrCommandZip),
 			0,
-			(GInstanceInitFunc) fr_command_zip_init
+			(GInstanceInitFunc) fr_command_zip_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command-zoo.c
+++ b/src/fr-command-zoo.c
@@ -415,7 +415,8 @@ fr_command_zoo_get_type ()
 			NULL,
 			sizeof (FrCommandZoo),
 			0,
-			(GInstanceInitFunc) fr_command_zoo_init
+			(GInstanceInitFunc) fr_command_zoo_init,
+			NULL
 		};
 
 		type = g_type_register_static (FR_TYPE_COMMAND,

--- a/src/fr-command.c
+++ b/src/fr-command.c
@@ -94,7 +94,8 @@ fr_command_get_type ()
 			NULL,
 			sizeof (FrCommand),
 			0,
-			(GInstanceInitFunc) fr_command_init
+			(GInstanceInitFunc) fr_command_init,
+			NULL
 		};
 
 		type = g_type_register_static (G_TYPE_OBJECT,

--- a/src/fr-list-model.c
+++ b/src/fr-list-model.c
@@ -145,6 +145,7 @@ fr_list_model_get_type (void)
 			sizeof (FRListModel),
 			0,
 			(GInstanceInitFunc) fr_list_model_init,
+			NULL
 		};
 
 		static const GInterfaceInfo multi_drag_source_info = {

--- a/src/fr-process.c
+++ b/src/fr-process.c
@@ -244,7 +244,8 @@ fr_process_get_type (void)
 			NULL,
 			sizeof (FrProcess),
 			0,
-			(GInstanceInitFunc) fr_process_init
+			(GInstanceInitFunc) fr_process_init,
+			NULL
 		};
 
 		type = g_type_register_static (G_TYPE_OBJECT,

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -835,7 +835,8 @@ fr_window_get_type (void)
 			NULL,
 			sizeof (FrWindow),
 			0,
-			(GInstanceInitFunc) fr_window_init
+			(GInstanceInitFunc) fr_window_init,
+			NULL
 		};
 
 		type = g_type_register_static (GTK_TYPE_APPLICATION_WINDOW,

--- a/src/ui.h
+++ b/src/ui.h
@@ -29,11 +29,11 @@
 
 
 static GtkActionEntry action_entries[] = {
-	{ "FileMenu", NULL, N_("_Archive") },
-	{ "EditMenu", NULL, N_("_Edit") },
-	{ "ViewMenu", NULL, N_("_View") },
-	{ "HelpMenu", NULL, N_("_Help") },
-	{ "ArrangeFilesMenu", NULL, N_("_Arrange Files") },
+	{ "FileMenu",         NULL, N_("_Archive"),       NULL, NULL, NULL },
+	{ "EditMenu",         NULL, N_("_Edit"),          NULL, NULL, NULL },
+	{ "ViewMenu",         NULL, N_("_View"),          NULL, NULL, NULL },
+	{ "HelpMenu",         NULL, N_("_Help"),          NULL, NULL, NULL },
+	{ "ArrangeFilesMenu", NULL, N_("_Arrange Files"), NULL, NULL, NULL },
 
 	{ "About", "help-about",
 	  N_("_About"), NULL,


### PR DESCRIPTION
caja-engrampa.c:439:2: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘const struct _GTypeInfo’} [-Wmissing-field-initializers]
eggtreemultidnd.c:70:2: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘const struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command.c:98:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-7z.c:750:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-ace.c:334:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-alz.c:397:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-ar.c:383:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-arj.c:429:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command.c:98:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-cfile.c:692:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-cpio.c:319:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-dpkg.c:305:17: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-iso.c:308:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-jar.c:234:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-lha.c:408:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-lrzip.c:262:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-rar.c:832:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-rpm.c:319:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-tar.c:1267:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-unarchiver.c:361:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-unstuff.c:381:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-zip.c:513:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-command-zoo.c:419:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-window.c:839:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-list-model.c:148:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘const struct _GTypeInfo’} [-Wmissing-field-initializers]
fr-process.c:248:3: warning: missing initializer for field ‘value_table’ of ‘GTypeInfo’ {aka ‘struct _GTypeInfo’} [-Wmissing-field-initializers]
ui.h:32:2: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘struct _GtkActionEntry’} [-Wmissing-field-initializers]
ui.h:33:2: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘struct _GtkActionEntry’} [-Wmissing-field-initializers]
ui.h:34:2: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘struct _GtkActionEntry’} [-Wmissing-field-initializers]
ui.h:35:2: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘struct _GtkActionEntry’} [-Wmissing-field-initializers]
ui.h:36:2: warning: missing initializer for field ‘accelerator’ of ‘GtkActionEntry’ {aka ‘struct _GtkActionEntry’} [-Wmissing-field-initializers]