### PR TITLE
glib-utils: Remove get_time_string

### DIFF
--- a/src/dlg-prop.c
+++ b/src/dlg-prop.c
@@ -135,7 +135,10 @@ dlg_prop (FrWindow *window)
 	set_label (label_label, _("Last modified:"));
 
 	label = _gtk_builder_get_widget (data->builder, "p_date_label");
-	s = get_time_string (get_file_mtime (fr_window_get_archive_uri (window)));
+	GDateTime *date_time;
+	date_time = g_date_time_new_from_unix_local (get_file_mtime (fr_window_get_archive_uri (window)));
+	s = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
+	g_date_time_unref (date_time);
 	gtk_label_set_text (GTK_LABEL (label), s);
 	g_free (s);
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -1600,10 +1600,14 @@ fr_window_populate_file_list (FrWindow  *window,
 
 			s_size = g_format_size (fdata->dir_size);
 
-			if (fdata->list_dir)
+			if (fdata->list_dir) {
 				s_time = g_strdup ("");
-			else
-				s_time = get_time_string (fdata->modified);
+			} else {
+				GDateTime *date_time;
+				date_time = g_date_time_new_from_unix_local (fdata->modified);
+				s_time = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
+				g_date_time_unref (date_time);
+			}
 
 			gtk_list_store_set (window->priv->list_store, &iter,
 					    COLUMN_FILE_DATA, fdata,
@@ -1620,6 +1624,7 @@ fr_window_populate_file_list (FrWindow  *window,
 			g_free (s_time);
 		}
 		else {
+			GDateTime  *date_time;
 			char       *utf8_path;
 			char       *s_size;
 			char       *s_time;
@@ -1628,7 +1633,9 @@ fr_window_populate_file_list (FrWindow  *window,
 			utf8_path = g_filename_display_name (fdata->path);
 
 			s_size = g_format_size (fdata->size);
-			s_time = get_time_string (fdata->modified);
+			date_time = g_date_time_new_from_unix_local (fdata->modified);
+			s_time = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
+			g_date_time_unref (date_time);
 			desc = g_content_type_get_description (fdata->content_type);
 
 			gtk_list_store_set (window->priv->list_store, &iter,

--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -547,27 +547,6 @@ debug (const char *file,
 }
 
 
-char *
-get_time_string (time_t time)
-{
-	struct tm *tm;
-	char       s_time[256];
-	char      *locale_format = NULL;
-	char      *time_utf8;
-
-	tm = localtime (&time);
-	/* This is the time format used in the "Date Modified" column and
-	 * in the Properties dialog.  See the man page of strftime for an
-	 * explanation of the values. */
-	locale_format = g_locale_from_utf8 (_("%d %B %Y, %H:%M"), -1, NULL, NULL, NULL);
-	strftime (s_time, sizeof (s_time) - 1, locale_format, tm);
-	g_free (locale_format);
-	time_utf8 = g_locale_to_utf8 (s_time, -1, NULL, NULL, NULL);
-
-	return time_utf8;
-}
-
-
 void
 g_ptr_array_free_full (GPtrArray *array,
                        GFunc      free_func,

--- a/src/glib-utils.h
+++ b/src/glib-utils.h
@@ -65,7 +65,6 @@ char **             split_line                   (const char  *line,
 const char *        get_last_field               (const char  *line,
 						  int          last_field);
 int                 n_fields                     (char       **str_array);
-char *              get_time_string              (time_t       time);
 void                g_ptr_array_free_full        (GPtrArray   *array,
                        				  GFunc        func,
                        				  gpointer     user_data);


### PR DESCRIPTION
`get_time_string()` is a local function that wraps `strftime()`. In contrast to `strftime()`, `g_date_time_format()` always produces a UTF-8 string, regardless of the current locale.