### PR TITLE
remove warnings: cast from function call [-Wbad-function-cast]

### DIFF
--- a/src/dlg-batch-add.c
+++ b/src/dlg-batch-add.c
@@ -510,7 +510,7 @@ dlg_batch_add_files (FrWindow *window,
 	gtk_button_set_label (GTK_BUTTON (GET_WIDGET ("a_add_button")), FR_STOCK_CREATE_ARCHIVE);
 	gtk_expander_set_expanded (GTK_EXPANDER (GET_WIDGET ("a_other_options_expander")), FALSE /*g_settings_get_boolean (data->settings, PREF_BATCH_ADD_OTHER_OPTIONS)*/);
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (GET_WIDGET ("a_encrypt_header_checkbutton")), g_settings_get_boolean (data->settings_general, PREF_GENERAL_ENCRYPT_HEADER));
-	gtk_spin_button_set_value (GTK_SPIN_BUTTON (GET_WIDGET ("a_volume_spinbutton")), (double) g_settings_get_int (data->settings, PREF_BATCH_ADD_VOLUME_SIZE) / MEGABYTE);
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (GET_WIDGET ("a_volume_spinbutton")), g_settings_get_int (data->settings, PREF_BATCH_ADD_VOLUME_SIZE) / MEGABYTE);
 
 
 	first_filename = (char*) file_list->data;

--- a/src/dlg-new.c
+++ b/src/dlg-new.c
@@ -36,7 +36,7 @@
 #define GET_WIDGET(x) (_gtk_builder_get_widget (data->builder, (x)))
 #define DEFAULT_EXTENSION ".tar.gz"
 #define BAD_CHARS "/\\*"
-#define MEGABYTE (1024 * 1024)
+#define MEGABYTE (1024.0 * 1024.0)
 
 
 /* called when the main dialog is closed. */
@@ -318,7 +318,7 @@ dlg_new_archive (FrWindow  *window,
         g_object_unref (settings);
 
         settings = g_settings_new (ENGRAMPA_SCHEMA_BATCH_ADD);
-        gtk_spin_button_set_value (GTK_SPIN_BUTTON (data->n_volume_spinbutton), (double) g_settings_get_int (settings, PREF_BATCH_ADD_VOLUME_SIZE) / MEGABYTE);
+        gtk_spin_button_set_value (GTK_SPIN_BUTTON (data->n_volume_spinbutton), g_settings_get_int (settings, PREF_BATCH_ADD_VOLUME_SIZE) / MEGABYTE);
         g_object_unref (settings);
 
 	/* format chooser */

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -26,7 +26,7 @@
 #include <glib.h>
 #include <glib-object.h>
 
-#define MEGABYTE (1024 * 1024)
+#define MEGABYTE (1024.0 * 1024.0)
 
 #define ADD_FOLDER_OPTIONS_DIR  "engrampa/options"
 


### PR DESCRIPTION
```
 dlg-batch-add.c:513:83: warning: cast from function call of type ‘gint’ {aka ‘int’} to non-matching type ‘double’ [-Wbad-function-cast]
   513 |  gtk_spin_button_set_value (GTK_SPIN_BUTTON (GET_WIDGET ("a_volume_spinbutton")), (double) g_settings_get_int (data->settings, PREF_BATCH_ADD_VOLUME_SIZE) / MEGABYTE);
       |                                                                                   ^

 dlg-new.c:321:81: warning: cast from function call of type ‘gint’ {aka ‘int’} to non-matching type ‘double’ [-Wbad-function-cast]
   321 |         gtk_spin_button_set_value (GTK_SPIN_BUTTON (data->n_volume_spinbutton), (double) g_settings_get_int (settings, PREF_BATCH_ADD_VOLUME_SIZE) / MEGABYTE);
       |                                                                                 ^
```
### Test
```shell
$ echo "1440*1024" | bc
1474560
$ gsettings set org.mate.engrampa.dialogs.batch-add volume-size 1474560
```
Right click on a folder in caja, select "Compress...". The compress dialog is shown as follows:

![Screenshot at 2019-09-03 12-08-20](https://user-images.githubusercontent.com/10171411/64165007-7191f680-ce44-11e9-9d12-027d2c507193.png)

Mark the checkbox "Split into volumes of:" and click on Create button.

```shell
$ stat --format="%s" test.7z.001
1474560
```

### Test 2

Right click on a folder in caja, select "Compress...". Mark the checkbox "Split into volumes of:" and select/write 1.6. Click on Create button.

![Screenshot at 2019-09-03 12-28-34](https://user-images.githubusercontent.com/10171411/64166153-da7a6e00-ce46-11e9-9272-fdedf001d21e.png)

```shell
$ gsettings get org.mate.engrampa.dialogs.batch-add volume-size
1677721
$ stat --format="%s" test2.7z.001
1677721
```