### PR TITLE
unace 2.5: Don't show archive summary in file listing

### DIFF
--- a/src/fr-command-ace.c
+++ b/src/fr-command-ace.c
@@ -120,6 +120,9 @@ process_line (char     *line,
 		return;
 	}
 
+	if (g_str_has_prefix (line, "listed"))
+		return;
+
 	fdata = file_data_new ();
 
 	if (ace_comm->command_type == FR_ACE_COMMAND_PUBLIC)


### PR DESCRIPTION
closes #303

Before:
![Captura de pantalla a 2019-09-08 22-20-21](https://user-images.githubusercontent.com/10171411/64494130-4155b800-d289-11e9-8d59-7d9422bba273.png)

After:
![Captura de pantalla a 2019-09-08 22-24-42](https://user-images.githubusercontent.com/10171411/64494132-49155c80-d289-11e9-8915-95d136d7a43b.png)

```shell
$ unace v -y ~/test.ace 

UNACE v2.5     Copyright by ACE Compression Software       Jun 18 2017 19:18:45
                                                                          
processing archive /home/robert/test.ace                                  
Main comment                                                              
This is a comment.
created on 8.9.2019 with ver 2.0 by                                       
*UNREGISTERED VERSION*                                                    
Contents of archive test.ace                                              
                                                                          
  Date    Time     Packed      Size  Ratio  File                          
                                                                          
08.09.19 21:32           0         0    0%  test/folder/blank             
08.09.19 21:29          13        13  100%  test/README.txt               
                                                                          
listed: 2 files, totaling 13 bytes (compressed 13)                        
```