### PR TITLE
remove warnings: ‘gtk_image_new_from_stock’ is deprecated

### DIFF
--- a/src/dlg-add-folder.c
+++ b/src/dlg-add-folder.c
@@ -878,8 +878,8 @@ save_options_cb (GtkWidget  *w,
 				_("_Options Name:"),
 				(data->last_options != NULL) ? data->last_options : "",
 				1024,
-				"gtk-cancel",
-				"gtk-save");
+				_("_Cancel"),
+				_("_Save"));
 	if (opt_filename == NULL)
 		return;
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -7854,7 +7854,7 @@ fr_window_rename_selection (FrWindow *window,
 						 (renaming_dir ? _("_New folder name:") : _("_New file name:")),
 						 utf8_old_name,
 						 1024,
-						 "gtk-cancel",
+						 _("_Cancel"),
 						 _("_Rename"));
 	g_free (utf8_old_name);
 
@@ -8295,8 +8295,8 @@ fr_window_paste_selection (FrWindow *window,
 					       _("_Destination folder:"),
 					       utf8_old_path,
 					       1024,
-					       "gtk-cancel",
-					       "gtk-paste");
+					       _("_Cancel"),
+					       _("_Paste"));
 	g_free (utf8_old_path);
 	if (utf8_path == NULL)
 		return;

--- a/src/gtk-utils.c
+++ b/src/gtk-utils.c
@@ -150,30 +150,19 @@ _gtk_message_dialog_new (GtkWindow        *parent,
 
 
 static GtkWidget *
-create_button (const char *stock_id,
+create_button (const char *icon_name,
 	       const char *text)
 {
+	GtkIconTheme *icon_theme;
 	GtkWidget    *button;
-	GtkWidget    *image;
-	const char   *label_text;
-	gboolean      text_is_stock;
-	GtkStockItem  stock_item;
 
-	if (gtk_stock_lookup (text, &stock_item)) {
-		label_text = stock_item.label;
-		text_is_stock = TRUE;
-	} else {
-		label_text = text;
-		text_is_stock = FALSE;
+	button = gtk_button_new_with_mnemonic (text);
+	icon_theme = gtk_icon_theme_get_default ();
+	if (gtk_icon_theme_has_icon (icon_theme, icon_name)) {
+		GtkWidget *image;
+		image = gtk_image_new_from_icon_name (icon_name, GTK_ICON_SIZE_BUTTON);
+		gtk_button_set_image (GTK_BUTTON (button), image);
 	}
-
-	if (text_is_stock)
-		image = gtk_image_new_from_stock (text, GTK_ICON_SIZE_BUTTON);
-	else
-		image = gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_BUTTON);
-	button = gtk_button_new_with_mnemonic (label_text);
-	gtk_button_set_image (GTK_BUTTON (button), image);
-
 	gtk_widget_set_can_default (button, TRUE);
 
 	gtk_widget_show (button);
@@ -244,7 +233,7 @@ _gtk_request_dialog_run (GtkWindow        *parent,
 
 	/* Add buttons */
 
-	button = create_button ("gtk-cancel", no_button_text);
+	button = create_button ("process-stop", no_button_text);
 	gtk_dialog_add_action_widget (GTK_DIALOG (dialog),
 				      button,
 				      GTK_RESPONSE_CANCEL);


### PR DESCRIPTION
```
gtk-utils.c:171:3: warning: ‘gtk_image_new_from_stock’ is deprecated: Use 'gtk_image_new_from_icon_name' instead [-Wdeprecated-declarations]
  171 |   image = gtk_image_new_from_stock (text, GTK_ICON_SIZE_BUTTON);
      |   ^~~~~

gtk-utils.c:173:3: warning: ‘gtk_image_new_from_stock’ is deprecated: Use 'gtk_image_new_from_icon_name' instead [-Wdeprecated-declarations]
  173 |   image = gtk_image_new_from_stock (stock_id, GTK_ICON_SIZE_BUTTON);
      |   ^~~~~
```