### PR TITLE
ar: don't remove leading whitespaces in filename field

### DIFF
--- a/src/fr-command-ar.c
+++ b/src/fr-command-ar.c
@@ -102,14 +102,14 @@ ar_get_last_field (const char *line,
 	while ((field_n > 0) && (*f_end != 0)) {
 		if (*f_end == ' ') {
 			field_n--;
-			if (field_n != 0) {
-				while ((*f_end == ' ') && (*f_end != *line))
-					f_end++;
+			if (field_n == 1)
 				f_start = f_end;
-			}
-		} else
-			f_end++;
+		}
+		f_end++;
 	}
+
+	if (*f_start == ' ')
+		f_start++;
 
 	return g_strdup (f_start);
 }


### PR DESCRIPTION
test:
```shell
$ touch " test"
$ touch "  test"
$ ar r test.a " test" "  test"
$ ar tv test.a
rw-rw-r-- 1000/1001	 0 Sep 18 14:58 2019  test
rw-rw-r-- 1000/1001	 0 Sep 18 14:58 2019   test
$ engrampa test.a
```