### PR TITLE
archive properties dialog: make properties reading easier

### DIFF
--- a/src/ui/properties.ui
+++ b/src/ui/properties.ui
@@ -73,7 +73,7 @@
               <object class="GtkLabel" id="p_name_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes" context="File">Name:</property>
                 <property name="justify">center</property>
                 <attributes>
@@ -89,7 +89,7 @@
               <object class="GtkLabel" id="p_size_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes">Archive size:</property>
                 <property name="justify">center</property>
                 <attributes>
@@ -129,7 +129,7 @@
               <object class="GtkLabel" id="p_cratio_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes">Compression ratio:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
@@ -156,7 +156,7 @@
               <object class="GtkLabel" id="p_uncomp_size_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes">Content size:</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
@@ -195,7 +195,7 @@
               <object class="GtkLabel" id="p_files_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes">Number of files:</property>
                 <property name="justify">center</property>
                 <attributes>
@@ -237,7 +237,7 @@
               <object class="GtkLabel" id="p_path_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes">Location:</property>
                 <property name="justify">center</property>
                 <attributes>
@@ -253,7 +253,7 @@
               <object class="GtkLabel" id="p_date_label_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
+                <property name="halign">end</property>
                 <property name="label" translatable="yes">Last modified:</property>
                 <property name="justify">center</property>
                 <attributes>


### PR DESCRIPTION
Removing the additional separation between the name of the
property and its value, it makes properties reading easier.

### Before

<img width="792" alt="Captura de Pantalla 2019-09-21 a les 23 56 03" src="https://user-images.githubusercontent.com/10171411/65379640-77ecf300-dccb-11e9-8487-a9dad32afecc.png">


### After

<img width="801" alt="Captura de Pantalla 2019-09-21 a les 23 35 26" src="https://user-images.githubusercontent.com/10171411/65379604-f9905100-dcca-11e9-9da8-825df4c622f9.png">
