### PR TITLE
Use mate-compiler-flags.m4 provided by mate-common

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ env:
 requires:
   archlinux:
     # Useful URL: https://git.archlinux.org/svntogit/community.git/tree/engrampa
+    - autoconf-archive
     - caja
     - clang
     - file
@@ -80,6 +81,7 @@ requires:
   debian:
     # Useful URL: https://github.com/mate-desktop/debian-packages
     # Useful URL: https://salsa.debian.org/debian-mate-team/engrampa
+    - autoconf-archive
     - clang
     - clang-tools
     - cppcheck
@@ -98,6 +100,7 @@ requires:
 
   fedora:
     # Useful URL: https://src.fedoraproject.org/cgit/rpms/engrampa.git
+    - autoconf-archive
     - caja-devel
     - clang
     - clang-analyzer
@@ -114,6 +117,7 @@ requires:
     - redhat-rpm-config
 
   ubuntu:
+    - autoconf-archive
     - clang
     - clang-tools
     - gettext

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ build_scripts:
   -     curl -Ls -o debian.sh https://github.com/mate-desktop/mate-dev-scripts/raw/master/travis/debian.sh
   -     bash ./debian.sh
   - fi
-  - ./autogen.sh
+  - ./autogen.sh --enable-compile-warnings=maximum
   - scan-build $CHECKERS ./configure
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $(( $CPU_COUNT + 1 ))
@@ -166,6 +166,19 @@ build_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     cppcheck --enable=warning,style,performance,portability,information,missingInclude .
   - fi
+
+before_scripts:
+  - cd ${START_DIR}
+  - '[ -f mate-common-1.23.3.tar.xz ] || curl -Ls -o mate-common-1.23.3.tar.xz http://pub.mate-desktop.org/releases/1.23/mate-common-1.23.3.tar.xz'
+  - tar xf mate-common-1.23.3.tar.xz
+  - cd mate-common-1.23.3
+  - if [ ${DISTRO_NAME} == "debian" -o ${DISTRO_NAME} == "ubuntu" ];then
+  -     ./configure --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu --libexecdir=/usr/lib/x86_64-linux-gnu
+  - else
+  -     ./configure --prefix=/usr
+  - fi
+  - make
+  - make install
 
 after_scripts:
   - if [ ${DISTRO_NAME} == "fedora" ];then

--- a/caja/Makefile.am
+++ b/caja/Makefile.am
@@ -1,4 +1,5 @@
 AM_CPPFLAGS =						\
+	$(WARN_CFLAGS)					\
 	-DFR_DATADIR=\"$(datadir)\"			\
 	-DMATELOCALEDIR=\""$(datadir)/locale"\" 	\
 	-I$(top_srcdir)					\

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 MATE_COMMON_INIT
+MATE_COMPILE_WARNINGS
 
 AC_PROG_CC
 AM_DISABLE_STATIC
@@ -45,26 +46,6 @@ dnl ===========================================================================
 PKG_CHECK_MODULES(GTK, [gtk+-3.0 >= $GTK_REQUIRED])
 AC_SUBST([GTK_CFLAGS])
 AC_SUBST([GTK_LIBS])
-
-dnl ===========================================================================
-
-WARN_CFLAGS="-Wall -Wcast-align -Wtype-limits -Wclobbered -Wempty-body -Wignored-qualifiers"
-
-for option in $WARN_CFLAGS; do
-	SAVE_CFLAGS="$CFLAGS"
-	CFLAGS="$CFLAGS $option"
-	AC_MSG_CHECKING([whether gcc understands $option])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],[has_option=yes],[has_option=no])
-	if test x$has_option = xyes; then
-		WARNINGS="$WARNINGS $option"
-	fi
-	AC_MSG_RESULT($has_option)
-	CFLAGS="$SAVE_CFLAGS"
-	unset has_option
-	unset SAVE_CFLAGS
-done
-unset option
-CFLAGS="$CFLAGS $WARNINGS"
 
 dnl ===========================================================================
 

--- a/copy-n-paste/Makefile.am
+++ b/copy-n-paste/Makefile.am
@@ -1,10 +1,15 @@
+NULL =
+
 AM_CPPFLAGS = \
 	-UGETTEXT_PACKAGE
 
 noinst_LTLIBRARIES = libeggsmclient.la
 
 libeggsmclient_la_LIBADD = $(GTK_LIBS)
-libeggsmclient_la_CFLAGS = $(GTK_CFLAGS)
+libeggsmclient_la_CFLAGS = 		\
+	$(GTK_CFLAGS)			\
+	$(WARN_CFLAGS)			\
+	$(NULL)
 libeggsmclient_la_SOURCES = eggdesktopfile.h \
 			    eggdesktopfile.c \
 			    eggsmclient.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,5 @@
+NULL =
+
 SUBDIRS = commands sh ui
 
 bin_PROGRAMS = engrampa
@@ -36,7 +38,9 @@ AM_CPPFLAGS =						\
 	-DPRIVEXECDIR=\"$(privexecdir)\"		\
 	-DSHDIR=\"$(shdir)\"				\
 	$(FR_CFLAGS)					\
-	$(JSON_GLIB_CFLAGS)
+	$(JSON_GLIB_CFLAGS)				\
+	$(WARN_CFLAGS)					\
+	$(NULL)
 
 BUILT_SOURCES =			\
 	fr-marshal.c		\

--- a/src/commands/Makefile.am
+++ b/src/commands/Makefile.am
@@ -1,7 +1,12 @@
+NULL =
+
 privexecdir = $(libexecdir)/$(PACKAGE)
 privexec_PROGRAMS = rpm2cpio
 
-AM_CPPFLAGS = $(FR_CFLAGS)
+AM_CPPFLAGS = 				\
+	$(FR_CFLAGS)			\
+	$(WARN_CFLAGS)			\
+	$(NULL)
 
 rpm2cpio_SOURCES = rpm2cpio.c
 rpm2cpio_LDADD = $(FR_LIBS)


### PR DESCRIPTION
USAGE: ./autogen.sh --enable-compile-warnings=no/minimum/yes/maximum/error@

If --enable-compile-warnings is not provided, the default is --enable-compile-warnings=yes

It requires https://github.com/mate-desktop/mate-common/pull/27, plus autoconf-archive package on build.