### PR TITLE
LHA: make compatible with content-type response from gio file query

### DIFF
--- a/src/fr-command-lha.c
+++ b/src/fr-command-lha.c
@@ -309,7 +309,7 @@ fr_command_lha_extract (FrCommand  *comm,
 }
 
 
-const char *lha_mime_type[] = { "application/x-lzh-compressed", NULL };
+const char *lha_mime_type[] = { "application/x-lzh-compressed", "application/x-lha",  NULL };
 
 
 static const char **


### PR DESCRIPTION
gio returns "application/x-lha" in get_mime_type_from_content

test:
```
$ gio info test.lzh | grep content-type
  standard::content-type: application/x-lha
  standard::fast-content-type: application/x-lha
$ grep x-lha /usr/share/mime/packages/* 
/usr/share/mime/packages/freedesktop.org.xml:  <mime-type type="application/x-lha">
```
file and xdg-mime return the current Lha mimetype, application/x-lha is an alias.
```shell
$ file -b --mime-type test.lzh 
application/x-lzh-compressed
$ xdg-mime query filetype test.lzh 
application/x-lzh-compressed
```