### PR TITLE
Set compiler debug flags using MATE_DEBUG_CHECK and update configure summary

### DIFF
--- a/caja/caja-engrampa.c
+++ b/caja/caja-engrampa.c
@@ -60,7 +60,7 @@ extract_to_callback (CajaMenuItem *item,
 		g_free (quoted_uri);
 	}
 
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 	g_print ("EXEC: %s\n", cmd->str);
 #endif
 
@@ -96,7 +96,7 @@ extract_here_callback (CajaMenuItem *item,
 
 	g_spawn_command_line_async (cmd->str, NULL);
 
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 	g_print ("EXEC: %s\n", cmd->str);
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_CONFIG_HEADER([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 MATE_COMMON_INIT
+MATE_DEBUG_CHECK([no])
 MATE_COMPILE_WARNINGS
 
 AC_PROG_CC
@@ -198,6 +199,9 @@ Configuration:
 
 	Source code location:   ${srcdir}
 	Compiler:               ${CC}
+        Compiler flags:         ${CFLAGS}
+        Warning flags:          ${WARN_CFLAGS}
+        Linker flags:           ${LDFLAGS}
 	Caja support:           ${enable_caja_actions}
 	PackageKit support:     ${enable_packagekit}
 	Run in place            ${enable_run_in_place}

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -689,8 +689,8 @@ action_started (FrCommand *command,
 		FrAction   action,
 		FrArchive *archive)
 {
-#ifdef DEBUG
-	debug (DEBUG_INFO, "%s [START] (FR::Archive)\n", action_names[action]);
+#ifdef MATE_ENABLE_DEBUG
+	debug (DEBUG_INFO, "%s [START] (FR::Archive)\n", get_action_name (action));
 #endif
 
 	g_signal_emit (G_OBJECT (archive),
@@ -926,8 +926,8 @@ action_performed (FrCommand   *command,
 		  FrProcError *error,
 		  FrArchive   *archive)
 {
-#ifdef DEBUG
-	debug (DEBUG_INFO, "%s [DONE] (FR::Archive)\n", action_names[action]);
+#ifdef MATE_ENABLE_DEBUG
+	debug (DEBUG_INFO, "%s [DONE] (FR::Archive)\n", get_action_name (action));
 #endif
 
 	switch (action) {

--- a/src/fr-command-cfile.c
+++ b/src/fr-command-cfile.c
@@ -20,6 +20,8 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <config.h>
+
 #include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -76,7 +78,7 @@ get_uncompressed_name_from_archive (FrCommand  *comm,
 			while (g_input_stream_read (stream, buffer, 1, NULL, NULL) > 0) {
 				if (buffer[0] == '\0') {
 					filename = g_strdup (file_name_from_path (str->str));
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 					g_message ("filename is: %s", filename);
 #endif
 					break;

--- a/src/fr-command.c
+++ b/src/fr-command.c
@@ -20,6 +20,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <config.h>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
@@ -78,6 +79,13 @@ const char *action_names[] = { "NONE",
                                "COPYING_FILES_TO_REMOTE",
                                "CREATING_ARCHIVE",
                                "SAVING_REMOTE_ARCHIVE" };
+
+#if MATE_ENABLE_DEBUG
+const char * get_action_name (FrAction action)
+{
+	return action_names[action];
+}
+#endif
 
 GType
 fr_command_get_type ()

--- a/src/fr-command.h
+++ b/src/fr-command.h
@@ -23,6 +23,7 @@
 #ifndef FR_COMMAND_H
 #define FR_COMMAND_H
 
+#include <config.h>
 #include <glib.h>
 #include "file-data.h"
 #include "fr-process.h"
@@ -59,8 +60,8 @@ typedef enum {
 	FR_ACTION_SAVING_REMOTE_ARCHIVE       /* copying the archive to a remote location */
 } FrAction;
 
-#ifdef DEBUG
-extern char *action_names[];
+#if MATE_ENABLE_DEBUG
+const char * get_action_name (FrAction action);
 #endif
 
 struct _FrCommand

--- a/src/fr-process.c
+++ b/src/fr-process.c
@@ -20,6 +20,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <config.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -739,7 +740,7 @@ start_current_command (FrProcess *process)
 
 	argv[i] = NULL;
 
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 	{
 		int j;
 
@@ -946,7 +947,7 @@ check_child (gpointer data)
 	if (continue_process) {
 		if (process->error.type != FR_PROC_ERROR_NONE) {
 			allow_sticky_processes_only (process, TRUE);
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 			{
 				GList *scan;
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -2901,8 +2901,8 @@ action_started (FrArchive *archive,
 	window->priv->action = action;
 	fr_window_start_activity_mode (window);
 
-#ifdef DEBUG
-	debug (DEBUG_INFO, "%s [START] (FR::Window)\n", action_names[action]);
+#ifdef MATE_ENABLE_DEBUG
+	debug (DEBUG_INFO, "%s [START] (FR::Window)\n", get_action_name (action));
 #endif
 
 	message = get_action_description (action, window->priv->pd_last_archive);
@@ -3163,8 +3163,8 @@ convert__action_performed (FrArchive   *archive,
 {
 	FrWindow *window = data;
 
-#ifdef DEBUG
-	debug (DEBUG_INFO, "%s [CONVERT::DONE] (FR::Window)\n", action_names[action]);
+#ifdef MATE_ENABLE_DEBUG
+	debug (DEBUG_INFO, "%s [CONVERT::DONE] (FR::Window)\n", get_action_name (action));
 #endif
 
 	if ((action == FR_ACTION_GETTING_FILE_LIST) || (action == FR_ACTION_ADDING_FILES)) {
@@ -3203,8 +3203,8 @@ action_performed (FrArchive   *archive,
 	char     *archive_dir;
 	gboolean  temp_dir;
 
-#ifdef DEBUG
-	debug (DEBUG_INFO, "%s [DONE] (FR::Window)\n", action_names[action]);
+#ifdef MATE_ENABLE_DEBUG
+	debug (DEBUG_INFO, "%s [DONE] (FR::Window)\n", get_action_name (action));
 #endif
 
 	fr_window_stop_activity_mode (window);
@@ -8118,8 +8118,8 @@ copy_from_archive_action_performed_cb (FrArchive   *archive,
 	FrWindow *window = data;
 	gboolean  UNUSED_VARIABLE continue_batch = FALSE;
 
-#ifdef DEBUG
-	debug (DEBUG_INFO, "%s [DONE] (FR::Window)\n", action_names[action]);
+#ifdef MATE_ENABLE_DEBUG
+	debug (DEBUG_INFO, "%s [DONE] (FR::Window)\n", get_action_name (action));
 #endif
 
 	fr_window_stop_activity_mode (window);

--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -20,6 +20,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <config.h>
 #include <string.h>
 #include <stdio.h>
 #include <glib.h>
@@ -472,7 +473,7 @@ debug (const char *file,
        const char *function,
        const char *format, ...)
 {
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 	va_list  args;
 	char    *str;
 

--- a/src/java-utils.c
+++ b/src/java-utils.c
@@ -20,6 +20,7 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <config.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
@@ -226,7 +227,7 @@ load_constant_pool_utfs (JavaClassFile *cfile)
 		i++;
 	}
 
-#ifdef DEBUG
+#ifdef MATE_ENABLE_DEBUG
 	g_print( "Number of Entries: %d\n", i );
 #endif
 }


### PR DESCRIPTION
test:
```
$ ./autogen.sh --enable-debug=profile --prefix=/usr
<cut>
Configuration:

	Source code location:   .
	Compiler:               gcc
        Compiler flags:          -g -pg
        Warning flags:          -Wall -Wmissing-prototypes
        Linker flags:            -pg
	Caja support:           yes
	PackageKit support:     yes
	Run in place            no
	Use libmagic:           no
	JSON support:           yes

Now type `make' to compile engrampa
```
test:
```
$ ./autogen.sh --enable-debug --prefix=/usr
<cut>
Configuration:

	Source code location:   .
	Compiler:               gcc
        Compiler flags:          -g -O0
        Warning flags:          -Wall -Wmissing-prototypes
        Linker flags:           
	Caja support:           yes
	PackageKit support:     yes
	Run in place            no
	Use libmagic:           no
	JSON support:           yes

Now type `make' to compile engrampa
$ grep MATE_ENABLE_DEBUG config.h
#define MATE_ENABLE_DEBUG 1
```