### PR TITLE
Travis CI: use Debian "testing" instead "sid"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ after_success:
 
 env:
   - DISTRO="archlinux/base"
-  - DISTRO="debian:sid"
+  - DISTRO="debian:testing"
   - DISTRO="fedora:30"
   - DISTRO="ubuntu:19.10"
 


### PR DESCRIPTION
Fixes debian travis build

@mate-desktop/core-team if you agree, I will do the same in all the repositories to the master and 1.22 branches.

Debian testing have packages more tested, and give us less problems.