### PR TITLE
ci: set maximum compile warnings on step scan-build ./configure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,7 @@ build_scripts:
   -     bash ./debian.sh
   - fi
   - ./autogen.sh --enable-compile-warnings=maximum
-  - scan-build $CHECKERS ./configure
+  - scan-build $CHECKERS ./configure --enable-compile-warnings=maximum
   - if [ $CPU_COUNT -gt 1 ]; then
   -     scan-build $CHECKERS --keep-cc -o html-report make -j $(( $CPU_COUNT + 1 ))
   - else


### PR DESCRIPTION
The autogen.sh compiler warning flags are overridden in configure step.