### PR TITLE
Fix localized pause UI logic

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -2304,7 +2304,7 @@ static void change_button_label (FrWindow  *window,
 	const gchar *state;
 	state = gtk_button_get_label (GTK_BUTTON (button));
 
-	if (g_strrstr ("_Pause", state) != NULL)
+	if (g_strrstr (_("_Pause"), state) != NULL)
 	{
 		gtk_widget_set_visible (window->priv->pd_progress_bar, FALSE);
 		fr_command_message (window->archive->command, _("Process paused"));


### PR DESCRIPTION
Pause/Resume button doesn't update the UI state on non-English localized environments. This fixes it for my language, and hopefully for all the others too.