### PR TITLE
fr-process: do not override LC_CTYPE

### DIFF
--- a/src/fr-process.c
+++ b/src/fr-process.c
@@ -640,8 +640,11 @@ child_setup (gpointer user_data)
 {
 	FrProcess *process = user_data;
 
-	if (process->priv->use_standard_locale)
-		putenv ("LC_ALL=C");
+	if (process->priv->use_standard_locale) {
+		putenv ("LC_MESSAGES=C");
+		putenv ("LC_TIME=C");
+		putenv ("LC_NUMERIC=C");
+	}
 
 	/* detach from the tty */
 
@@ -744,8 +747,11 @@ start_current_command (FrProcess *process)
 	{
 		int j;
 
-		if (process->priv->use_standard_locale)
-			g_print ("\tLC_ALL=C\n");
+		if (process->priv->use_standard_locale) {
+			g_print ("\tLC_MESSAGES=C\n");
+			g_print ("\tLC_TIME=C\n");
+			g_print ("\tLC_NUMERIC=C\n");
+		}
 
 		if (info->dir != NULL)
 			g_print ("\tcd %s\n", info->dir);


### PR DESCRIPTION
Closes #354

Test:
```shell
[robert@localhost engrampa]$ CFLAGS="-g -O0" ./autogen.sh --prefix=/usr --enable-debug && make && sudo make install
<cut>
[robert@localhost engrampa]$ engrampa /home/robert/テスト.rar
```
Before
```shell
[FR] fr-window.c:2905 (action_started):
	LOADING_ARCHIVE [START] (FR::Window)

[FR] fr-window.c:3207 (action_performed):
	LOADING_ARCHIVE [DONE] (FR::Window)

[FR] fr-command.c:589 (fr_command_set_filename):
	filename : /home/robert/テスト.rar

[FR] fr-command.c:590 (fr_command_set_filename):
	e_filename : '/home/robert/テスト.rar'

[FR] fr-archive.c:697 (action_started):
	LISTING_CONTENT [START] (FR::Archive)

[FR] fr-window.c:2905 (action_started):
	LISTING_CONTENT [START] (FR::Window)

[FR] fr-process.c:682 (start_current_command):
	0/0) 
	LC_ALL=C
	unrar v -c- -v -p- -- /home/robert/テスト.rar 
** ERROR **
No such file or directory
Cannot open /home/robert/??????????.ra

[FR] fr-archive.c:934 (action_performed):
	LISTING_CONTENT [DONE] (FR::Archive)

[FR] fr-window.c:3207 (action_performed):
	LISTING_CONTENT [DONE] (FR::Window)
```

After
```shell
[FR] fr-window.c:2905 (action_started):
	LOADING_ARCHIVE [START] (FR::Window)

[FR] fr-window.c:3207 (action_performed):
	LOADING_ARCHIVE [DONE] (FR::Window)

[FR] fr-command.c:589 (fr_command_set_filename):
	filename : /home/robert/テスト.rar

[FR] fr-command.c:590 (fr_command_set_filename):
	e_filename : '/home/robert/テスト.rar'

[FR] fr-archive.c:697 (action_started):
	LISTING_CONTENT [START] (FR::Archive)

[FR] fr-window.c:2905 (action_started):
	LISTING_CONTENT [START] (FR::Window)

[FR] fr-process.c:685 (start_current_command):
	0/0) 
	LC_MESSAGES=C
	LC_TIME=C
	LC_NUMERIC=C
	unrar v -c- -v -p- -- /home/robert/テスト.rar 
[FR] fr-archive.c:934 (action_performed):
	LISTING_CONTENT [DONE] (FR::Archive)

[FR] fr-window.c:3207 (action_performed):
	LISTING_CONTENT [DONE] (FR::Window)
```