### PR TITLE
Fix build using gcc 10 -fno-common flag

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -33,8 +33,6 @@
 
 #include "fr-init.h"
 
-gint          ForceDirectoryCreation;
-
 static char **remaining_args;
 static char  *add_to = NULL;
 static int    add;


### PR DESCRIPTION
```
/usr/bin/ld: main.o:(.bss+0x0): multiple definition of `ForceDirectoryCreation'; fr-init.o:(.bss+0x8): first defined here
```