### PR TITLE
Terminate the application if the resource doesn't exists

### DIFF
--- a/src/dlg-add-files.c
+++ b/src/dlg-add-files.c
@@ -140,9 +140,7 @@ add_files_cb (GtkWidget *widget,
 	DialogData *data;
 	char       *folder;
 
-	builder = _gtk_builder_new_from_resource ("dlg-add-files.ui");
-	if (builder == NULL)
-		return;
+	builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "dlg-add-files.ui");
 
 	data = g_new0 (DialogData, 1);
 	data->window = callback_data;

--- a/src/dlg-add-folder.c
+++ b/src/dlg-add-folder.c
@@ -204,10 +204,7 @@ add_folder_cb (GtkWidget *widget,
 	GtkBuilder  *builder;
 	DialogData  *data;
 
-	builder = _gtk_builder_new_from_resource ("dlg-add-folder.ui");
-	if (builder == NULL) {
-		return;
-	}
+	builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "dlg-add-folder.ui");
 
 	data = g_new0 (DialogData, 1);
 	data->window = callback_data;
@@ -668,11 +665,7 @@ load_options_cb (GtkWidget  *w,
 	aod_data = g_new0 (LoadOptionsDialogData, 1);
 
 	aod_data->data = data;
-	aod_data->builder = _gtk_builder_new_from_resource ("add-options.ui");
-	if (aod_data->builder == NULL) {
-		g_free (aod_data);
-		return;
-	}
+	aod_data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "add-options.ui");
 
 	/* Get the widgets. */
 

--- a/src/dlg-ask-password.c
+++ b/src/dlg-ask-password.c
@@ -97,13 +97,7 @@ dlg_ask_password__common (FrWindow       *window,
 	char       *name = NULL;
 
 	data = g_new0 (DialogData, 1);
-
-	data->builder = _gtk_builder_new_from_resource ("batch-password.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return;
-	}
-
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "batch-password.ui");
 	data->window = window;
 	data->pwd_type = pwd_type;
 

--- a/src/dlg-batch-add.c
+++ b/src/dlg-batch-add.c
@@ -484,13 +484,7 @@ dlg_batch_add_files (FrWindow *window,
 	data = g_new0 (DialogData, 1);
 	data->settings = g_settings_new (ENGRAMPA_SCHEMA_BATCH_ADD);
 	data->settings_general = g_settings_new (ENGRAMPA_SCHEMA_GENERAL);
-
-	data->builder = _gtk_builder_new_from_resource ("batch-add-files.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return;
-	}
-
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "batch-add-files.ui");
 	data->window = window;
 	data->file_list = file_list;
 	data->single_file = ((file_list->next == NULL) && uri_is_file ((char*) file_list->data));

--- a/src/dlg-delete.c
+++ b/src/dlg-delete.c
@@ -114,12 +114,7 @@ dlg_delete__common (FrWindow *window,
 	data = g_new (DialogData, 1);
 	data->window = window;
 	data->selected_files = selected_files;
-
-	data->builder = _gtk_builder_new_from_resource ("delete.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return;
-	}
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "delete.ui");
 
 	/* Get the widgets. */
 

--- a/src/dlg-extract.c
+++ b/src/dlg-extract.c
@@ -295,10 +295,7 @@ dlg_extract__common (FrWindow *window,
 	DialogData *data;
 
 	data = g_new0 (DialogData, 1);
-	if ((data->builder = _gtk_builder_new_from_resource ("dlg-extract.ui")) == NULL) {
-		g_free (data);
-		return;
-	}
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "dlg-extract.ui");
 	data->settings = g_settings_new (ENGRAMPA_SCHEMA_EXTRACT);
 	data->window = window;
 	data->selected_files = selected_files;

--- a/src/dlg-new.c
+++ b/src/dlg-new.c
@@ -272,13 +272,7 @@ dlg_new_archive (FrWindow  *window,
 	int            i;
 
 	data = g_new0 (DlgNewData, 1);
-
-	data->builder = _gtk_builder_new_from_resource ("new.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return NULL;
-	}
-
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "new.ui");
 	data->window = window;
 	data->supported_types = supported_types;
 	sort_mime_types_by_description (data->supported_types);

--- a/src/dlg-password.c
+++ b/src/dlg-password.c
@@ -88,13 +88,7 @@ dlg_password (GtkWidget *widget,
 	DialogData *data;
 
 	data = g_new0 (DialogData, 1);
-
-	data->builder = _gtk_builder_new_from_resource ("password.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return;
-	}
-
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "password.ui");
 	data->window = window;
 
 	/* Get the widgets. */

--- a/src/dlg-prop.c
+++ b/src/dlg-prop.c
@@ -72,12 +72,7 @@ dlg_prop (FrWindow *window)
 	double            ratio;
 
 	data = g_new (DialogData, 1);
-
-	data->builder = _gtk_builder_new_from_resource ("properties.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return;
-	}
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "properties.ui");
 
 	/* Get the widgets. */
 

--- a/src/dlg-update.c
+++ b/src/dlg-update.c
@@ -284,13 +284,7 @@ dlg_update (FrWindow *window)
 	GtkTreeViewColumn *column;
 
 	data = g_new0 (DialogData, 1);
-
-	data->builder = _gtk_builder_new_from_resource ("update.ui");
-	if (data->builder == NULL) {
-		g_free (data);
-		return NULL;
-	}
-
+	data->builder = gtk_builder_new_from_resource (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S "update.ui");
 	data->file_list = NULL;
 	data->window = window;
 

--- a/src/gtk-utils.c
+++ b/src/gtk-utils.c
@@ -596,25 +596,6 @@ show_help_dialog (GtkWindow  *parent,
 }
 
 
-GtkBuilder *
-_gtk_builder_new_from_resource (const char *resource_path)
-{
-	GtkBuilder *builder;
-	char       *full_path;
-	GError     *error = NULL;
-
-	builder = gtk_builder_new ();
-	full_path = g_strconcat (ENGRAMPA_RESOURCE_UI_PATH G_DIR_SEPARATOR_S, resource_path, NULL);
-        if (! gtk_builder_add_from_resource (builder, full_path, &error)) {
-                g_warning ("%s\n", error->message);
-                g_clear_error (&error);
-        }
-	g_free (full_path);
-
-        return builder;
-}
-
-
 GtkWidget *
 _gtk_builder_get_widget (GtkBuilder *builder,
 			 const char *name)

--- a/src/gtk-utils.h
+++ b/src/gtk-utils.h
@@ -66,8 +66,6 @@ GdkPixbuf * get_mime_type_pixbuf            (const char   *mime_type,
 		                             GtkIconTheme *icon_theme);
 void        show_help_dialog                (GtkWindow    *parent,
 					     const char   *section);
-GtkBuilder *
-	   _gtk_builder_new_from_resource   (const char   *resource_path);
 GtkWidget *
 	    _gtk_builder_get_widget         (GtkBuilder   *builder,
 			 		     const char   *name);


### PR DESCRIPTION
It terminates engrampa and it shows the message below when the RESOURCE doesn't exist:
```
(engrampa:25129): Gtk-ERROR **: 23:11:24.338: failed to add UI: The resource at “/org/mate/Engrampa/ui/RESOURCE” does not exist
Trace/breakpoint trap (core dumped)
```
It removes the warnings below:

GCC 10 analyzer:
```
$ CFLAGS="-fanalyzer" ./autogen.sh --prefix=/usr && make
```
warnings:
```
In function ‘dlg_new’:
dlg-new.c:426:40: warning: dereference of NULL ‘data’ [CWE-690] [-Wanalyzer-null-dereference]
  426 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "New"));
/usr/include/glib-2.0/gobject/gtype.h:2301:57: note: in definition of macro ‘_G_TYPE_CIC’
 2301 |     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
      |                                                         ^~
/usr/include/gtk-3.0/gtk/gtkwindow.h:40:28: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
   40 | #define GTK_WINDOW(obj)   (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
dlg-new.c:426:24: note: in expansion of macro ‘GTK_WINDOW’
  426 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "New"));
      |                        ^~~~~~~~~~
  ‘dlg_new’: events 1-2
    |
    |  421 | dlg_new (FrWindow *window)
    |      | ^~~~~~~
    |      | |
    |      | (1) entry to ‘dlg_new’
    |......
    |  425 |  data = dlg_new_archive (window, create_type, NULL);
    |      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (2) calling ‘dlg_new_archive’ from ‘dlg_new’
    |
    +--> ‘dlg_new_archive’: events 3-5
           |
           |  266 | dlg_new_archive (FrWindow  *window,
           |      | ^~~~~~~~~~~~~~~
           |      | |
           |      | (3) entry to ‘dlg_new_archive’
           |......
           |  279 |  if (data->builder == NULL) {
           |      |     ~
           |      |     |
           |      |     (4) following ‘true’ branch...
           |  280 |   g_free (data);
           |      |   ~~~~~~~~~~~~~
           |      |   |
           |      |   (5) ...to here
           |
         ‘dlg_new_archive’: event 6
           |
           |cc1:
           | (6): assuming ‘<return-value>’ is NULL
           |
    <------+
    |
  ‘dlg_new’: event 7
    |
    |  425 |  data = dlg_new_archive (window, create_type, NULL);
    |      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (7) return of NULL to ‘dlg_new’ from ‘dlg_new_archive’
    |
  ‘dlg_new’: event 8
    |
    |  426 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "New"));
/usr/include/glib-2.0/gobject/gtype.h:2301:57: note: in definition of macro ‘_G_TYPE_CIC’
    | 2301 |     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
    |      |                                                         ^~
/usr/include/gtk-3.0/gtk/gtkwindow.h:40:28: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
    |   40 | #define GTK_WINDOW(obj)   (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
    |      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
dlg-new.c:426:24: note: in expansion of macro ‘GTK_WINDOW’
    |  426 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "New"));
    |      |                        ^~~~~~~~~~
    |
In function ‘dlg_save_as’:
dlg-new.c:439:40: warning: dereference of NULL ‘data’ [CWE-690] [-Wanalyzer-null-dereference]
  439 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "Save"));
/usr/include/glib-2.0/gobject/gtype.h:2301:57: note: in definition of macro ‘_G_TYPE_CIC’
 2301 |     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
      |                                                         ^~
/usr/include/gtk-3.0/gtk/gtkwindow.h:40:28: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
   40 | #define GTK_WINDOW(obj)   (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
dlg-new.c:439:24: note: in expansion of macro ‘GTK_WINDOW’
  439 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "Save"));
      |                        ^~~~~~~~~~
  ‘dlg_save_as’: events 1-2
    |
    |  433 | dlg_save_as (FrWindow   *window,
    |      | ^~~~~~~~~~~
    |      | |
    |      | (1) entry to ‘dlg_save_as’
    |......
    |  438 |  data = dlg_new_archive (window, save_type, default_name);
    |      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (2) calling ‘dlg_new_archive’ from ‘dlg_save_as’
    |
    +--> ‘dlg_new_archive’: events 3-5
           |
           |  266 | dlg_new_archive (FrWindow  *window,
           |      | ^~~~~~~~~~~~~~~
           |      | |
           |      | (3) entry to ‘dlg_new_archive’
           |......
           |  279 |  if (data->builder == NULL) {
           |      |     ~
           |      |     |
           |      |     (4) following ‘true’ branch...
           |  280 |   g_free (data);
           |      |   ~~~~~~~~~~~~~
           |      |   |
           |      |   (5) ...to here
           |
         ‘dlg_new_archive’: event 6
           |
           |cc1:
           | (6): assuming ‘<return-value>’ is NULL
           |
    <------+
    |
  ‘dlg_save_as’: event 7
    |
    |  438 |  data = dlg_new_archive (window, save_type, default_name);
    |      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |         |
    |      |         (7) return of NULL to ‘dlg_save_as’ from ‘dlg_new_archive’
    |
  ‘dlg_save_as’: event 8
    |
    |  439 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "Save"));
/usr/include/glib-2.0/gobject/gtype.h:2301:57: note: in definition of macro ‘_G_TYPE_CIC’
    | 2301 |     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
    |      |                                                         ^~
/usr/include/gtk-3.0/gtk/gtkwindow.h:40:28: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
    |   40 | #define GTK_WINDOW(obj)   (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
    |      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
dlg-new.c:439:24: note: in expansion of macro ‘GTK_WINDOW’
    |  439 |  gtk_window_set_title (GTK_WINDOW (data->dialog), C_("File", "Save"));
    |      |                        ^~~~~~~~~~
    |
```