### PR TITLE
glib-utils: remove g_ptr_array_free_full

### DIFF
--- a/src/fr-command.c
+++ b/src/fr-command.c
@@ -506,7 +506,7 @@ fr_command_class_init (FrCommandClass *class)
 static void
 fr_command_init (FrCommand *comm)
 {
-	comm->files = g_ptr_array_sized_new (INITIAL_SIZE);
+	comm->files = g_ptr_array_new_full (INITIAL_SIZE, (GDestroyNotify) file_data_free);
 
 	comm->password = NULL;
 	comm->encrypt_header = FALSE;
@@ -545,7 +545,7 @@ fr_command_finalize (GObject *object)
 	g_free (comm->e_filename);
 	g_free (comm->password);
 	if (comm->files != NULL)
-		g_ptr_array_free_full (comm->files, (GFunc) file_data_free, NULL);
+		g_ptr_array_free (comm->files, TRUE);
 	fr_command_set_process (comm, NULL);
 
 	/* Chain up */
@@ -624,8 +624,8 @@ fr_command_list (FrCommand *comm)
 	fr_command_progress (comm, -1.0);
 
 	if (comm->files != NULL) {
-		g_ptr_array_free_full (comm->files, (GFunc) file_data_free, NULL);
-		comm->files = g_ptr_array_sized_new (INITIAL_SIZE);
+		g_ptr_array_free (comm->files, TRUE);
+		comm->files = g_ptr_array_new_full (INITIAL_SIZE, (GDestroyNotify) file_data_free);
 	}
 
 	comm->action = FR_ACTION_LISTING_CONTENT;

--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -476,16 +476,6 @@ debug (const char *file,
 }
 
 
-void
-g_ptr_array_free_full (GPtrArray *array,
-                       GFunc      free_func,
-                       gpointer   user_data)
-{
-	g_ptr_array_foreach (array, free_func, user_data);
-	g_ptr_array_free (array, TRUE);
-}
-
-
 GHashTable *static_strings = NULL;
 
 

--- a/src/glib-utils.h
+++ b/src/glib-utils.h
@@ -59,9 +59,6 @@ char **             split_line                   (const char  *line,
 						  int          n_fields);
 const char *        get_last_field               (const char  *line,
 						  int          last_field);
-void                g_ptr_array_free_full        (GPtrArray   *array,
-                       				  GFunc        func,
-                       				  gpointer     user_data);
 const char *        get_static_string            (const char  *s);
 char*               g_uri_display_basename       (const char  *uri);
 


### PR DESCRIPTION
Removed warnings:
```
fr-command.c:548:39: warning: cast between incompatible function types from ‘void (*)(FileData *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  548 |   g_ptr_array_free_full (comm->files, (GFunc) file_data_free, NULL);
      |                                       ^
--
fr-command.c:627:39: warning: cast between incompatible function types from ‘void (*)(FileData *)’ to ‘void (*)(void *, void *)’ [-Wcast-function-type]
  627 |   g_ptr_array_free_full (comm->files, (GFunc) file_data_free, NULL);
      |                                       ^
```