### PR TITLE
gtk-utils: Remove _gtk_count_selected

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -3645,7 +3645,7 @@ fr_window_get_file_list (FrWindow *window)
 int
 fr_window_get_n_selected_files (FrWindow *window)
 {
-	return _gtk_count_selected (gtk_tree_view_get_selection (GTK_TREE_VIEW (window->priv->list_view)));
+	return gtk_tree_selection_count_selected_rows (gtk_tree_view_get_selection (GTK_TREE_VIEW (window->priv->list_view)));
 }
 
 

--- a/src/gtk-utils.c
+++ b/src/gtk-utils.c
@@ -28,29 +28,6 @@
 
 #define LOAD_BUFFER_SIZE 65536
 
-static void
-count_selected (GtkTreeModel *model,
-		GtkTreePath  *path,
-		GtkTreeIter  *iter,
-		gpointer      data)
-{
-	int *n = data;
-	*n = *n + 1;
-}
-
-
-int
-_gtk_count_selected (GtkTreeSelection *selection)
-{
-	int n = 0;
-
-	if (selection == NULL)
-		return 0;
-	gtk_tree_selection_selected_foreach (selection, count_selected, &n);
-	return n;
-}
-
-
 GtkWidget*
 _gtk_message_dialog_new (GtkWindow        *parent,
 			 GtkDialogFlags    flags,

--- a/src/gtk-utils.h
+++ b/src/gtk-utils.h
@@ -27,7 +27,6 @@
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
-int         _gtk_count_selected             (GtkTreeSelection *selection);
 GtkWidget*  _gtk_message_dialog_new         (GtkWindow        *parent,
 					     GtkDialogFlags    flags,
 					     const char       *icon_name,


### PR DESCRIPTION
Removed warnings:
```
gtk-utils.c:32:31: warning: unused parameter ‘model’ [-Wunused-parameter]
   32 | count_selected (GtkTreeModel *model,
      |                 ~~~~~~~~~~~~~~^~~~~
gtk-utils.c:33:17: warning: unused parameter ‘path’ [-Wunused-parameter]
   33 |   GtkTreePath  *path,
      |   ~~~~~~~~~~~~~~^~~~
gtk-utils.c:34:17: warning: unused parameter ‘iter’ [-Wunused-parameter]
   34 |   GtkTreeIter  *iter,
      |   ~~~~~~~~~~~~~~^~~~
```