### PR TITLE
egg: silent 'Unused parameter' warnings

### DIFF
--- a/copy-n-paste/eggsmclient-xsmp.c
+++ b/copy-n-paste/eggsmclient-xsmp.c
@@ -445,6 +445,8 @@ sm_client_xsmp_end_session (EggSMClient         *client,
 			    EggSMClientEndStyle  style,
 			    gboolean             request_confirmation)
 {
+  (void) style; /* unused parameter */
+
   EggSMClientXSMP *xsmp = (EggSMClientXSMP *)client;
   int save_type;
 
@@ -612,6 +614,8 @@ xsmp_save_yourself (SmcConn   smc_conn,
 		    int       interact_style,
 		    Bool      fast)
 {
+  (void) smc_conn; /* unused parameter */
+
   EggSMClientXSMP *xsmp = client_data;
   gboolean wants_quit_requested;
 
@@ -927,6 +931,8 @@ static void
 xsmp_interact (SmcConn   smc_conn,
 	       SmPointer client_data)
 {
+  (void) smc_conn; /* unused parameter */
+
   EggSMClientXSMP *xsmp = client_data;
   EggSMClient *client = client_data;
 
@@ -947,6 +953,8 @@ static void
 xsmp_die (SmcConn   smc_conn,
 	  SmPointer client_data)
 {
+  (void) smc_conn; /* unused parameter */
+
   EggSMClientXSMP *xsmp = client_data;
   EggSMClient *client = client_data;
 
@@ -961,6 +969,8 @@ static void
 xsmp_save_complete (SmcConn   smc_conn,
 		    SmPointer client_data)
 {
+  (void) smc_conn; /* unused parameter */
+
   EggSMClientXSMP *xsmp = client_data;
 
   g_debug ("Received SaveComplete message in state %s",
@@ -976,6 +986,8 @@ static void
 xsmp_shutdown_cancelled (SmcConn   smc_conn,
 			 SmPointer client_data)
 {
+  (void) smc_conn; /* unused parameter */
+
   EggSMClientXSMP *xsmp = client_data;
   EggSMClient *client = client_data;
 
@@ -1303,6 +1315,10 @@ ice_iochannel_watch (GIOChannel   *channel,
 		     GIOCondition  condition,
 		     gpointer      client_data)
 {
+  /* unused parameters */
+  (void) channel;
+  (void) condition;
+
   return process_ice_messages (client_data);
 }
 
@@ -1312,6 +1328,8 @@ ice_connection_watch (IceConn     ice_conn,
 		      Bool        opening,
 		      IcePointer *watch_data)
 {
+  (void) client_data; /* unused parameter */
+
   guint watch_id;
 
   if (opening)
@@ -1343,12 +1361,23 @@ ice_error_handler (IceConn       ice_conn,
 		   int           severity,
 		   IcePointer    values)
 {
+  /* unused parameters */
+  (void) ice_conn;
+  (void) swap;
+  (void) offending_minor_opcode;
+  (void) offending_sequence;
+  (void) error_class;
+  (void) severity;
+  (void) values;
+
   /* Do nothing */
 }
 
 static void
 ice_io_error_handler (IceConn ice_conn)
 {
+  (void) ice_conn; /* unused parameter */
+
   /* Do nothing */
 }
 
@@ -1361,5 +1390,14 @@ smc_error_handler (SmcConn       smc_conn,
                    int           severity,
                    SmPointer     values)
 {
+  /* unused parameters */
+  (void) smc_conn;
+  (void) swap;
+  (void) offending_minor_opcode;
+  (void) offending_sequence;
+  (void) error_class;
+  (void) severity;
+  (void) values;
+
   /* Do nothing */
 }

--- a/copy-n-paste/eggsmclient.c
+++ b/copy-n-paste/eggsmclient.c
@@ -52,7 +52,7 @@ static EggSMClientMode global_client_mode = EGG_SM_CLIENT_MODE_NORMAL;
 static void
 egg_sm_client_init (EggSMClient *client)
 {
-  ;
+  (void) client; /* unused parameter */
 }
 
 static void
@@ -182,6 +182,12 @@ sm_client_post_parse_func (GOptionContext  *context,
 			   gpointer         data,
 			   GError         **error)
 {
+  /* unused parameters */
+  (void) context;
+  (void) group;
+  (void) data;
+  (void) error;
+
   EggSMClient *client = egg_sm_client_get ();
 
   if (sm_client_id == NULL)
@@ -575,6 +581,8 @@ egg_sm_client_debug_handler (const char *log_domain,
 			     const char *message,
 			     gpointer user_data)
 {
+  (void) user_data; /* unused parameter */
+
   static int debug = -1;
 
   if (debug < 0)

--- a/src/eggfileformatchooser.c
+++ b/src/eggfileformatchooser.c
@@ -360,6 +360,8 @@ static void
 expander_unmap_cb (GtkWidget *widget,
 		   gpointer   user_data)
 {
+  (void) widget; /* unused parameter */
+
   EggFileFormatChooser *self = user_data;
 
   if (self->priv->size_changed_event == 0)
@@ -529,6 +531,8 @@ filter_changed_cb (GObject    *object,
                    GParamSpec *spec,
                    gpointer    data)
 {
+  (void) spec; /* unused parameter */
+
   EggFileFormatChooser *self;
 
   GtkFileFilter *current_filter;

--- a/src/eggtreemultidnd.c
+++ b/src/eggtreemultidnd.c
@@ -192,9 +192,7 @@ stop_drag_check (GtkWidget *widget)
 
 
 static gboolean
-egg_tree_multi_drag_button_release_event (GtkWidget      *widget,
-					  GdkEventButton *event,
-					  gpointer        data)
+egg_tree_multi_drag_button_release_event (GtkWidget      *widget)
 {
   EggTreeMultiDndData *priv_data;
   GSList *l;
@@ -216,6 +214,8 @@ selection_foreach (GtkTreeModel *model,
 		   GtkTreeIter  *iter,
 		   gpointer      data)
 {
+  (void) iter; /* unused parameter */
+
   GList **list_ptr;
 
   list_ptr = (GList **) data;
@@ -254,9 +254,7 @@ get_context_data (GdkDragContext *context)
 static gboolean
 egg_tree_multi_drag_drag_data_get (GtkWidget        *widget,
 				   GdkDragContext   *context,
-				   GtkSelectionData *selection_data,
-				   guint             info,
-				   guint             time)
+				   GtkSelectionData *selection_data)
 {
   GtkTreeView  *tree_view;
   GtkTreeModel *model;
@@ -291,6 +289,8 @@ egg_tree_multi_drag_motion_event (GtkWidget      *widget,
 				  GdkEventMotion *event,
 				  gpointer        data)
 {
+  (void) data; /* unused parameter */
+
   EggTreeMultiDndData *priv_data;
 
   priv_data = g_object_get_data (G_OBJECT (widget), EGG_TREE_MULTI_DND_STRING);
@@ -370,6 +370,8 @@ egg_tree_multi_drag_button_press_event (GtkWidget      *widget,
 					GdkEventButton *event,
 					gpointer        data)
 {
+  (void) data; /* unused parameter */
+
   GtkTreeView         *tree_view;
   GtkTreePath         *path = NULL;
   GtkTreeViewColumn   *column = NULL;


### PR DESCRIPTION
This is another way to silent the warnings, with (void) instead the gnu macro, I think it will be more portable