### PR TITLE
Travis CI: avoid deprecated skip_cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ script:
 
 deploy:
   - provider: pages
+    edge: true
     token: $GITHUB_TOKEN
     keep_history: false
-    skip_cleanup: true
     committer_from_gh: true
     target_branch: gh-pages
     local_dir: html-report
@@ -37,8 +37,8 @@ deploy:
       all_branches: true
       condition: ${DISTRO} =~ ^fedora.*$
   - provider: script
+    edge: true
     script: ./docker-build --verbose --config .build.yml --release github
-    skip_cleanup: true
     on:
       tags: true
       condition: "${TRAVIS_TAG} =~ ^v.*$ && ${DISTRO} =~ ^fedora.*$"


### PR DESCRIPTION
https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release#cleaning-up-the-git-working-directory