### PR TITLE
Travis CI: enable irc notifications with broken builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,18 @@ install:
 script:
   - ./docker-build --name ${DISTRO} --verbose --config .build.yml --build scripts
 
+notifications:
+  irc:
+    if: branch = master AND
+        repo = mate-desktop/engrampa
+    channels:
+      - "irc.freenode.org#mate-dev"
+    template:
+      - "[%{repository_name}] %{author}: %{commit_subject}"
+      - "%{commit} %{message} %{build_url}"
+    on_success: never
+    on_failure: always
+
 deploy:
   - provider: pages
     edge: true


### PR DESCRIPTION
This PR enables `irc` notifications on `#mate-dev` channel at freenode if the build in `master` branch fails, if the build is ok, it does nothing (to avoid the noise).

How to test: feel free to put here one more commit with the change:

```
-    if: branch = master AND
+    if: branch = travistest AND
```

and with one more little change to force the build to fail and see the #mate-dev channel.

revert the broken change to force the build ok, and see it doesn't notify to channel.

and finally keep the PR in the original state

If accepted I will do the same in all the repositories, and in stable branches