### PR TITLE
Update compilation instructions

### DIFF
--- a/README
+++ b/README
@@ -64,8 +64,8 @@
 
 * Dependencies
 
-  In order to build this program from the source code you need a working
-  MATE environment version 1.2, with the development tools installed
+  In order to build this program from the source code you need git installed and
+   a working MATE environment version 1.2, with the development tools installed
   properly.
 
   Also you need the following libraries:
@@ -75,6 +75,8 @@
 
 * Install
 
+  git submodule init
+  git submodule update
   ./autogen.sh
   make
   make install


### PR DESCRIPTION
After git submodule use, git is now need to compile Engrampa from the source code.
Added git in the dependencie section.
Added "git submodule init && git submodule update" command in the installation section.