### PR TITLE
Allow preferring unzip over 7z, as it supports OEM encodings (#5)

### DIFF
--- a/src/fr-init.c
+++ b/src/fr-init.c
@@ -363,9 +363,14 @@ register_commands (void)
 	 * have higher priority over commands that can only read the same
 	 * format, regardless of the registration order. */
 
+	/* Allow preferring unzip over 7z, as it supports OEM encodings (#5) */
+	gboolean prefer_zip = (getenv("UNZIP") != NULL);
+
 	register_command (FR_TYPE_COMMAND_TAR);
 	register_command (FR_TYPE_COMMAND_CFILE);
 	register_command (FR_TYPE_COMMAND_RAR);
+	if (prefer_zip)
+		register_command (FR_TYPE_COMMAND_ZIP);
 	register_command (FR_TYPE_COMMAND_7Z);
 	register_command (FR_TYPE_COMMAND_DPKG);
 
@@ -380,7 +385,8 @@ register_commands (void)
 	register_command (FR_TYPE_COMMAND_LHA);
 	register_command (FR_TYPE_COMMAND_RPM);
 	register_command (FR_TYPE_COMMAND_UNSTUFF);
-	register_command (FR_TYPE_COMMAND_ZIP);
+	if (!prefer_zip)
+		register_command (FR_TYPE_COMMAND_ZIP);
 	register_command (FR_TYPE_COMMAND_LRZIP);
 	register_command (FR_TYPE_COMMAND_ZOO);
 #if HAVE_JSON_GLIB


### PR DESCRIPTION
Hi, this PR addresses #5, i.e. it allows preferring unzip over 7z, because unzip supports OEM encodings and 7z doesn't and won't.

For example, if a Greek (or any non-English) user opens Windows explorer, right clicks on a folder and selects "Create .zip file", that .zip file can't be properly uncompressed with 7z, as it's using the OEM (DOS) encoding.

To tell unzip which OEM encoding was used, the user is expected to define the following environment variables:

```shell
export UNZIP="-O cp737"
export ZIPINFO="-O cp737"
```
Thus this patch checks if UNZIP is defined, and if so, it registers unzip before 7z.