### PR TITLE
Remove trailing spaces

### DIFF
--- a/src/fr-command-unarchiver.c
+++ b/src/fr-command-unarchiver.c
@@ -242,7 +242,7 @@ fr_command_unarchiver_handle_error (FrCommand   *comm,
 			char *line = scan->data;
 
 			if ((strstr (line, "This archive requires a password to unpack.") != NULL)  ||
-			    (strstr (line, "Failed! (Missing or wrong password)") != NULL)) { 
+			    (strstr (line, "Failed! (Missing or wrong password)") != NULL)) {
 
 				error->type = FR_PROC_ERROR_ASK_PASSWORD;
 				break;


### PR DESCRIPTION
```
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/[[:space:]]*$//' {} \;
find . \( -name '*.h' -o -name '*.c' \) -exec sed -i 's/\t*$//' {} \;
```