### PR TITLE
Remove cppcheck warnings about the variable scope can be reduced

### DIFF
--- a/caja/caja-engrampa.c
+++ b/caja/caja-engrampa.c
@@ -85,7 +85,7 @@ extract_here_callback (CajaMenuItem *item,
 
 	for (scan = files; scan; scan = scan->next) {
 		CajaFileInfo *file = scan->data;
-		char             *uri, *quoted_uri;
+		char *uri, *quoted_uri;
 
 		uri = caja_file_info_get_uri (file);
 		quoted_uri = g_shell_quote (uri);
@@ -106,12 +106,12 @@ extract_here_callback (CajaMenuItem *item,
 
 static void
 add_callback (CajaMenuItem *item,
-	      gpointer          user_data)
+              gpointer      user_data)
 {
-	GList            *files, *scan;
-	char             *uri, *dir;
-	char             *quoted_uri, *quoted_dir;
-	GString          *cmd;
+	GList     *files, *scan;
+	char      *uri, *dir;
+	char      *quoted_dir;
+	GString   *cmd;
 
 	files = g_object_get_data (G_OBJECT (item), "files");
 	uri = caja_file_info_get_uri (files->data);
@@ -126,6 +126,8 @@ add_callback (CajaMenuItem *item,
 	g_free (quoted_dir);
 
 	for (scan = files; scan; scan = scan->next) {
+		char *quoted_uri;
+
 		uri = caja_file_info_get_uri (scan->data);
 		quoted_uri = g_shell_quote (uri);
 		g_string_append_printf (cmd, " %s", quoted_uri);
@@ -295,7 +297,7 @@ caja_fr_get_file_items (CajaMenuProvider *provider,
 
 	for (scan = files; scan; scan = scan->next) {
 		CajaFileInfo *file = scan->data;
-		FileMimeInfo      file_mime_info;
+		FileMimeInfo file_mime_info;
 
 		file_mime_info = get_file_mime_info (file);
 

--- a/src/eggfileformatchooser.c
+++ b/src/eggfileformatchooser.c
@@ -99,11 +99,9 @@ egg_file_format_filter_info_new (const gchar *name,
 static void
 egg_file_format_filter_info_free (gpointer boxed)
 {
-  EggFileFormatFilterInfo *self;
-
   if (boxed)
     {
-      self = boxed;
+      EggFileFormatFilterInfo *self = boxed;
 
       g_hash_table_unref (self->extension_set);
       g_slist_free_full (self->extension_list, g_free);
@@ -164,7 +162,6 @@ egg_file_format_filter_add_extensions (GtkFileFilter *filter,
   GString *filter_name;
   gchar **strings;
   gchar **ptr;
-  gchar *pattern;
 
   g_assert (NULL != extensions);
 
@@ -185,7 +182,7 @@ egg_file_format_filter_add_extensions (GtkFileFilter *filter,
   strings = g_strsplit (extensions, ", ", -1);
   for (ptr = strings; *ptr; ptr++)
     {
-      pattern = g_strdup_printf ("*%s", *ptr);
+      gchar *pattern = g_strdup_printf ("*%s", *ptr);
 
       if (filter_name)
         {
@@ -211,7 +208,6 @@ static void
 selection_changed_cb (GtkTreeSelection     *selection,
                       EggFileFormatChooser *self)
 {
-  gchar *label;
   gchar *name;
 
   GtkFileFilter *filter;
@@ -221,6 +217,8 @@ selection_changed_cb (GtkTreeSelection     *selection,
 
   if (gtk_tree_selection_get_selected (selection, &model, &iter))
     {
+      gchar *label;
+
       gtk_tree_model_get (model, &iter, MODEL_COLUMN_NAME, &name, -1);
 
       label = g_strdup_printf (_("File _Format: %s"), name);
@@ -298,7 +296,6 @@ static gboolean
 accept_filename (gchar       *extensions,
                  const gchar *filename)
 {
-  const gchar *extptr;
   gchar *saveptr;
   gchar *token;
   gsize length;
@@ -308,6 +305,8 @@ accept_filename (gchar       *extensions,
   for (token = strtok_r (extensions, ",", &saveptr); NULL != token;
        token = strtok_r (NULL, ",", &saveptr))
     {
+      const gchar *extptr;
+
       token = g_strstrip (token);
       extptr = filename + length - strlen (token) - 1;
 
@@ -636,14 +635,14 @@ chooser_response_cb (GtkDialog *dialog,
                      gpointer   data)
 {
   EggFileFormatChooser *self;
-  gchar *filename, *basename;
-  gchar *message;
-  guint format;
 
   self = EGG_FILE_FORMAT_CHOOSER (data);
 
   if (EGG_IS_POSITIVE_RESPONSE (response_id))
     {
+      gchar *filename, *basename;
+      guint format;
+
       filename = gtk_file_chooser_get_filename (self->priv->chooser);
       basename = g_filename_display_basename (filename);
       g_free (filename);
@@ -653,6 +652,7 @@ chooser_response_cb (GtkDialog *dialog,
 
       if (0 == format)
         {
+          gchar *message;
 
           message = g_strdup_printf (
             _("The program was not able to find out the file format "
@@ -892,7 +892,6 @@ get_icon_name (const gchar *mime_type)
 {
   static gboolean first_call = TRUE;
   gchar *name = NULL;
-  gchar *s;
 
   if (first_call)
     {
@@ -903,6 +902,8 @@ get_icon_name (const gchar *mime_type)
 
   if (mime_type)
     {
+      gchar *s;
+
       name = g_strconcat ("mate-mime-", mime_type, NULL);
 
       for(s = name; *s; ++s)

--- a/src/eggtreemultidnd.c
+++ b/src/eggtreemultidnd.c
@@ -304,7 +304,6 @@ egg_tree_multi_drag_motion_event (GtkWidget      *widget,
       GList            *path_list = NULL;
       GtkTreeSelection *selection;
       GtkTreeModel     *model;
-      GdkDragContext   *context;
 
       stop_drag_check (widget);
 
@@ -318,10 +317,11 @@ egg_tree_multi_drag_motion_event (GtkWidget      *widget,
       model = gtk_tree_view_get_model (GTK_TREE_VIEW (widget));
       if (egg_tree_multi_drag_source_row_draggable (EGG_TREE_MULTI_DRAG_SOURCE (model), path_list))
 	{
-	  GtkTargetList *target_list;
-	  GtkTreePath   *tree_path;
-	  int            cell_x;
-	  int            cell_y;
+	  GdkDragContext *context;
+	  GtkTargetList  *target_list;
+	  GtkTreePath    *tree_path;
+	  int             cell_x;
+	  int             cell_y;
 
 	  target_list = gtk_target_list_new (target_table, G_N_ELEMENTS (target_table));
 	  context = gtk_drag_begin_with_coordinates (widget,

--- a/src/file-data.c
+++ b/src/file-data.c
@@ -147,9 +147,9 @@ int
 find_path_in_file_data_array (GPtrArray  *array,
 			      const char *path)
 {
-	int       path_l;
-	int       left, right, p, cmp = -1;
-	FileData *fd;
+	int path_l;
+	int left;
+	int right;
 
 	if (path == NULL)
 		return -1;
@@ -158,16 +158,23 @@ find_path_in_file_data_array (GPtrArray  *array,
 	left = 0;
 	right = array->len;
 	while (left < right) {
+		FileData *fd;
+		int p;
+		int cmp;
+
 		p = left + ((right - left) / 2);
 		fd = (FileData *) g_ptr_array_index (array, p);
-
 		cmp = strcmp (path, fd->original_path);
 		if (cmp != 0) {
 			/* consider '/path/to/dir' and '/path/to/dir/' the same path */
+			int original_path_l;
 
-			int original_path_l = strlen (fd->original_path);
+			original_path_l = strlen (fd->original_path);
+
 			if ((path_l == original_path_l - 1) && (fd->original_path[original_path_l - 1] == '/')) {
-				int cmp2 = strncmp (path, fd->original_path, original_path_l - 1);
+				int cmp2;
+
+				cmp2  = strncmp (path, fd->original_path, original_path_l - 1);
 				if (cmp2 == 0)
 					cmp = cmp2;
 			}

--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -903,12 +903,12 @@ get_temp_work_dir (const char *parent_folder)
 {
 	guint64  max_size = 0;
 	char    *best_folder = NULL;
-	int      i;
 	char    *template;
 	char    *result = NULL;
 
 	if (parent_folder == NULL) {
 		/* find the folder with more free space. */
+		int i;
 
 		for (i = 0; try_folder[i] != NULL; i++) {
 			char    *folder;

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -3335,10 +3335,11 @@ get_extract_here_destination (GFile   *file,
 	char  *desired_destination;
 	char  *destination = NULL;
 	int    n = 1;
-	GFile *directory;
 
 	desired_destination = get_desired_destination_for_archive (file);
 	do {
+		GFile *directory;
+
 		*error = NULL;
 
 		g_free (destination);

--- a/src/fr-command-cpio.c
+++ b/src/fr-command-cpio.c
@@ -49,19 +49,21 @@ mktime_from_string (char *month,
 		    char *mday,
 		    char *year)
 {
-	static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 	struct tm tm = {0, };
 
 	tm.tm_isdst = -1;
 
 	if (month != NULL) {
+		static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+		                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 		int i;
-		for (i = 0; i < 12; i++)
+
+		for (i = 0; i < 12; i++) {
 			if (strcmp (months[i], month) == 0) {
 				tm.tm_mon = i;
 				break;
 			}
+		}
 	}
 	tm.tm_mday = atoi (mday);
 	if (strchr (year, ':') != NULL) {

--- a/src/fr-command-iso.c
+++ b/src/fr-command-iso.c
@@ -47,19 +47,21 @@ mktime_from_string (char *month,
 		    char *mday,
 		    char *year)
 {
-	static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 	struct tm tm = {0, };
 
 	tm.tm_isdst = -1;
 
 	if (month != NULL) {
+		static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+		                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 		int i;
-		for (i = 0; i < 12; i++)
+
+		for (i = 0; i < 12; i++) {
 			if (strcmp (months[i], month) == 0) {
 				tm.tm_mon = i;
 				break;
 			}
+		}
 	}
 	tm.tm_mday = atoi (mday);
 	tm.tm_year = atoi (year) - 1900;

--- a/src/fr-command-lha.c
+++ b/src/fr-command-lha.c
@@ -48,27 +48,29 @@ mktime_from_string (char *month,
 		    char *mday,
 		    char *time_or_year)
 {
-	static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-	struct tm   tm = {0, };
-	char      **fields;
+	struct tm tm = {0, };
 
 	tm.tm_isdst = -1;
 
 	/* date */
 
 	if (month != NULL) {
+		static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+		                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 		int i;
-		for (i = 0; i < 12; i++)
+
+		for (i = 0; i < 12; i++) {
 			if (strcmp (months[i], month) == 0) {
 				tm.tm_mon = i;
 				break;
 			}
+		}
 	}
 	tm.tm_mday = atoi (mday);
 	if (strchr (time_or_year, ':') == NULL)
 		tm.tm_year = atoi (time_or_year) - 1900;
 	else {
+		char     **fields;
 		time_t     now;
 		struct tm *tm_now;
 
@@ -97,7 +99,7 @@ split_line_lha (char *line)
 {
 	char       **fields;
 	int          n_fields = 7;
-	const char  *scan, *field_end;
+	const char  *scan;
 	int          i;
 
 	fields = g_new0 (char *, n_fields + 1);
@@ -128,8 +130,9 @@ split_line_lha (char *line)
 
 	scan = eat_spaces (line);
 	for (; i < n_fields; i++) {
-		field_end = strchr (scan, ' ');
-		if (field_end != NULL) {
+		const char *field_end;
+
+		if (NULL != (field_end = strchr (scan, ' '))) {
 			fields[i] = g_strndup (scan, field_end - scan);
 			scan = eat_spaces (field_end);
 		}

--- a/src/fr-command-rpm.c
+++ b/src/fr-command-rpm.c
@@ -49,19 +49,22 @@ mktime_from_string (char *month,
 		    char *mday,
 		    char *year)
 {
-	static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                                        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
 	struct tm tm = {0, };
 
 	tm.tm_isdst = -1;
 
 	if (month != NULL) {
+		static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+		                                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
+
 		int i;
-		for (i = 0; i < 12; i++)
+
+		for (i = 0; i < 12; i++) {
 			if (strcmp (months[i], month) == 0) {
 				tm.tm_mon = i;
 				break;
 			}
+		}
 	} else
 		tm.tm_mon = 0;
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -2261,16 +2261,13 @@ static void change_button_label (FrWindow  *window,
 								    GTK_ICON_SIZE_BUTTON));
 	}
 }
-static void fr_state_switch (FrWindow  *window)
+
+static void
+fr_state_switch (FrWindow  *window)
 {
-	int ret;
-	if (window->archive->process != NULL)
-	{
-		ret = start_switch_state (window->archive->process);
-		if (ret == 0)
-		{
-			change_button_label (window, window->priv->pd_state_button);
-		}
+	if ((window->archive->process != NULL) &&
+	    ((start_switch_state (window->archive->process) == 0))) {
+		change_button_label (window, window->priv->pd_state_button);
 	}
 }
 
@@ -4308,7 +4305,7 @@ get_xds_atom_value (GdkDragContext *context)
 {
 	gint actual_length;
 	char *data;
-	char *ret;
+	char *ret = NULL;
 
 	g_return_val_if_fail (context != NULL, NULL);
 	g_return_val_if_fail (gdk_drag_context_get_source_window (context) != NULL, NULL);
@@ -4321,10 +4318,9 @@ get_xds_atom_value (GdkDragContext *context)
 		/* add not included \0 to the end of the string */
 		ret = g_strndup ((gchar *) data, actual_length);
 		g_free (data);
-		return ret;
 	}
 
-	return NULL;
+	return ret;
 }
 
 
@@ -4711,10 +4707,11 @@ fr_window_delete_event_cb (GtkWidget *caller,
 static gboolean
 is_single_click_policy (FrWindow *window)
 {
-	char     *value;
 	gboolean  result = FALSE;
 
 	if (window->priv->settings_caja) {
+		char *value;
+
 		value = g_settings_get_string (window->priv->settings_caja, CAJA_CLICK_POLICY);
 		result = (value != NULL) && (strncmp (value, "single", 6) == 0);
 		g_free (value);
@@ -4732,7 +4729,6 @@ filename_cell_data_func (GtkTreeViewColumn *column,
 			 FrWindow          *window)
 {
 	char           *text;
-	GtkTreePath    *path;
 	PangoUnderline  underline;
 
 	gtk_tree_model_get (model, iter,
@@ -4740,6 +4736,8 @@ filename_cell_data_func (GtkTreeViewColumn *column,
 			    -1);
 
 	if (window->priv->single_click) {
+		GtkTreePath *path;
+
 		path = gtk_tree_model_get_path (model, iter);
 
 		if ((window->priv->list_hover_path == NULL)

--- a/src/gtk-utils.c
+++ b/src/gtk-utils.c
@@ -254,11 +254,9 @@ _gtk_error_dialog_new (GtkWindow        *parent,
 	GtkWidget     *expander;
 	GtkWidget     *content_area;
 	GtkWidget     *action_area;
-	GtkTextBuffer *text_buf;
 	GtkTextIter    iter;
 	GList         *scan;
 	char          *escaped_message, *markup_text;
-	va_list        args;
 	gboolean       view_output = (row_output != NULL);
 
 	dialog = gtk_dialog_new_with_buttons ("",
@@ -287,6 +285,7 @@ _gtk_error_dialog_new (GtkWindow        *parent,
 
 	escaped_message = g_markup_escape_text (primary_text, -1);
 	if (secondary_text != NULL) {
+		va_list args;
 		char *secondary_message;
 		char *escaped_secondary_message;
 
@@ -309,6 +308,8 @@ _gtk_error_dialog_new (GtkWindow        *parent,
 	g_free (escaped_message);
 
 	if (view_output) {
+		GtkTextBuffer *text_buf;
+
 		gtk_widget_set_size_request (dialog, 500, -1);
 
 		/* Expander */


### PR DESCRIPTION
```
caja/caja-engrampa.c:113:20: style: The scope of the variable 'quoted_uri' can be reduced. [variableScope]
 char             *quoted_uri, *quoted_dir;
                   ^
mate-submodules/libegg/eggdesktopfile.c:497:9: style: The scope of the variable 'try_exec' can be reduced. [variableScope]
  char *try_exec, *found_program;
        ^
mate-submodules/libegg/eggdesktopfile.c:497:20: style: The scope of the variable 'found_program' can be reduced. [variableScope]
  char *try_exec, *found_program;
                   ^
mate-submodules/libegg/eggdesktopfile.c:498:10: style: The scope of the variable 'only_show_in' can be reduced. [variableScope]
  char **only_show_in, **not_show_in;
         ^
mate-submodules/libegg/eggdesktopfile.c:498:26: style: The scope of the variable 'not_show_in' can be reduced. [variableScope]
  char **only_show_in, **not_show_in;
                         ^
mate-submodules/libegg/eggdesktopfile.c:500:7: style: The scope of the variable 'i' can be reduced. [variableScope]
  int i;
      ^
mate-submodules/libegg/eggdesktopfile.c:622:15: style: The scope of the variable 'p' can be reduced. [variableScope]
  const char *p;
              ^
--
mate-submodules/libegg/eggsmclient-xsmp.c:804:23: style: The scope of the variable 'discard' can be reduced. [variableScope]
 GPtrArray *restart, *discard;
                      ^
mate-submodules/libegg/eggsmclient-xsmp.c:805:17: style: The scope of the variable 'fd' can be reduced. [variableScope]
    int offset, fd;
                ^
mate-submodules/libegg/eggsmclient-xsmp.c:851:30: style: The scope of the variable 'keys' can be reduced. [variableScope]
            char **groups, **keys, *value, *exec;
                             ^
--
src/eggfileformatchooser.c:102:28: style: The scope of the variable 'self' can be reduced. [variableScope]
  EggFileFormatFilterInfo *self;
                           ^
src/eggfileformatchooser.c:167:10: style: The scope of the variable 'pattern' can be reduced. [variableScope]
  gchar *pattern;
         ^
src/eggfileformatchooser.c:214:10: style: The scope of the variable 'label' can be reduced. [variableScope]
  gchar *label;
         ^
src/eggfileformatchooser.c:301:16: style: The scope of the variable 'extptr' can be reduced. [variableScope]
  const gchar *extptr;
               ^
src/eggfileformatchooser.c:639:10: style: The scope of the variable 'filename' can be reduced. [variableScope]
  gchar *filename, *basename;
         ^
src/eggfileformatchooser.c:639:21: style: The scope of the variable 'basename' can be reduced. [variableScope]
  gchar *filename, *basename;
                    ^
src/eggfileformatchooser.c:640:10: style: The scope of the variable 'message' can be reduced. [variableScope]
  gchar *message;
         ^
src/eggfileformatchooser.c:895:10: style: The scope of the variable 's' can be reduced. [variableScope]
  gchar *s;
         ^
--
src/eggtreemultidnd.c:307:25: style: The scope of the variable 'context' can be reduced. [variableScope]
      GdkDragContext   *context;
                        ^
src/file-data.c:151:25: style: The scope of the variable 'p' can be reduced. [variableScope]
 int       left, right, p, cmp = -1;
                        ^
src/file-data.c:151:28: style: The scope of the variable 'cmp' can be reduced. [variableScope]
 int       left, right, p, cmp = -1;
                           ^
src/file-data.c:152:12: style: The scope of the variable 'fd' can be reduced. [variableScope]
 FileData *fd;
           ^
--
src/file-utils.c:906:11: style: The scope of the variable 'i' can be reduced. [variableScope]
 int      i;
          ^
--
src/fr-archive.c:3338:9: style: The scope of the variable 'directory' can be reduced. [variableScope]
 GFile *directory;
        ^
src/fr-command-cpio.c:52:21: style: The scope of the variable 'months' can be reduced. [variableScope]
 static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                    ^
--
src/fr-command-iso.c:50:21: style: The scope of the variable 'months' can be reduced. [variableScope]
 static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                    ^
--
src/fr-command-lha.c:51:21: style: The scope of the variable 'months' can be reduced. [variableScope]
 static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                    ^
src/fr-command-lha.c:54:14: style: The scope of the variable 'fields' can be reduced. [variableScope]
 char      **fields;
             ^
src/fr-command-lha.c:100:22: style: The scope of the variable 'field_end' can be reduced. [variableScope]
 const char  *scan, *field_end;
                     ^
src/fr-command-rpm.c:52:21: style: The scope of the variable 'months' can be reduced. [variableScope]
 static const char *months[] = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                    ^
--
src/fr-window.c:2266:6: style: The scope of the variable 'ret' can be reduced. [variableScope]
 int ret;
     ^
src/fr-window.c:4311:8: style: The scope of the variable 'ret' can be reduced. [variableScope]
 char *ret;
       ^
src/fr-window.c:4714:12: style: The scope of the variable 'value' can be reduced. [variableScope]
 char     *value;
           ^
src/fr-window.c:4735:18: style: The scope of the variable 'path' can be reduced. [variableScope]
 GtkTreePath    *path;
                 ^
--
src/gtk-utils.c:257:17: style: The scope of the variable 'text_buf' can be reduced. [variableScope]
 GtkTextBuffer *text_buf;
                ^
src/gtk-utils.c:261:17: style: The scope of the variable 'args' can be reduced. [variableScope]
 va_list        args;
                ^
```