### PR TITLE
build: Use PACKAGE_URL variable

### DIFF
--- a/caja/Makefile.am
+++ b/caja/Makefile.am
@@ -19,12 +19,15 @@ libcaja_engrampa_la_LDFLAGS = -module -avoid-version -no-undefined
 libcaja_engrampa_la_LIBADD  = $(CAJA_LIBS)
 
 extensiondir = $(datadir)/caja/extensions
-extension_in_files = libcaja-engrampa.caja-extension.desktop.in
+extension_in_in_files = libcaja-engrampa.caja-extension.desktop.in.in
+extension_in_files = $(extension_in_in_files:.caja-extension.desktop.in.in=.caja-extension.desktop.in)
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
 
+DISTCLEANFILES = $(extension_in_files)
 CLEANFILES = $(extension_DATA)
 
-EXTRA_DIST = $(extension_in_files)
+EXTRA_DIST = $(extension_in_in_files)
+
 -include $(top_srcdir)/git.mk

--- a/caja/libcaja-engrampa.caja-extension.desktop.in.in
+++ b/caja/libcaja-engrampa.caja-extension.desktop.in.in
@@ -6,4 +6,4 @@ Description=Allows to create and extract archives
 Author=Paolo Bacchilega <paolo.bacchilega@libero.it>;Perberos <perberos@gmail.com>
 Copyright=Copyright (C) 2001–2010 Free Software Foundation, Inc.\nCopyright (C) 2012–2021 The MATE developers
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=@PACKAGE_URL@

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
 
-AC_INIT([engrampa], [1.25.0], [https://mate-desktop.org])
+AC_INIT([engrampa], [1.25.0], [https://github.com/mate-desktop/engrampa/issues], [engrampa], [https://mate-desktop.org])
 AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip check-news])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
@@ -228,6 +228,7 @@ dnl ******************************
 
 AC_CONFIG_FILES([Makefile
 		 data/Makefile
+		 data/engrampa.appdata.xml.in
 		 data/engrampa.desktop.in
 		 data/org.mate.engrampa.gschema.xml
 		 data/icons/Makefile

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = icons
 
 desktopdir = $(datadir)/applications
 desktop_in_in_files = engrampa.desktop.in.in
-desktop_in_files = $(desktop_in_in_files:.desktop.in.in=.desktop.in) 
+desktop_in_files = $(desktop_in_in_files:.desktop.in.in=.desktop.in)
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 $(desktop_DATA): $(desktop_in_files)
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
@@ -17,7 +17,8 @@ $(service_DATA): $(service_in_files) Makefile
 	$(AM_V_GEN) $(SED) -e "s|\@libexecdir\@|$(libexecdir)|" $< > $@
 
 appdatadir = $(datadir)/metainfo
-appdata_in_files = engrampa.appdata.xml.in
+appdata_in_in_files = engrampa.appdata.xml.in.in
+appdata_in_files = $(appdata_in_in_files:.xml.in.in=.xml.in)
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 $(appdata_DATA): $(appdata_in_files)
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
@@ -44,27 +45,27 @@ update-cache:
 	fi
 
 EXTRA_DIST = \
-       packages.match.in \
-       packages.match \
-       $(desktop_in_in_files) \
-       $(desktop_in_files) \
-       $(desktop_DATA) \
-       $(gsettingsschema_in_files) \
-       $(appdata_in_files) \
-       $(man_MANS) \
-       $(service_in_files) \
-       $(NULL)
+	packages.match.in \
+	packages.match \
+	$(appdata_in_in_files) \
+	$(desktop_in_in_files) \
+	$(gsettingsschema_in_files) \
+	$(man_MANS) \
+	$(service_in_files) \
+	$(NULL)
 
 DISTCLEANFILES = \
-       $(desktop_in_files) \
-       $(desktop_DATA) \
-       $(service_DATA) \
-       $(NULL)
+	$(appdata_in_files) \
+	$(desktop_in_files) \
+	$(service_DATA) \
+	$(NULL)
 
 CLEANFILES = \
-       $(gsettings_SCHEMAS) \
-       engrampa.appdata.xml \
-       $(NULL)
+	$(appdata_DATA) \
+	$(desktop_DATA) \
+	$(gsettings_SCHEMAS) \
+	engrampa.appdata.xml \
+	$(NULL)
 
 dist-hook:
 	cd $(distdir); rm -f $(CLEANFILES)

--- a/data/engrampa.appdata.xml.in.in
+++ b/data/engrampa.appdata.xml.in.in
@@ -66,7 +66,7 @@
    </image>
   </screenshot>
  </screenshots>
- <url type="homepage">http://www.mate-desktop.org</url>
+ <url type="homepage">@PACKAGE_URL@</url>
  <updatecontact>mate-dev@ml.mate-desktop.org</updatecontact>
  <project_group>MATE</project_group>
 </component>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -6,7 +6,7 @@ mate-submodules/libegg/eggsmclient.c
 mate-submodules/libegg/eggsmclient.h
 mate-submodules/libegg/eggsmclient-private.h
 mate-submodules/libegg/eggsmclient-xsmp.c
-data/engrampa.appdata.xml.in
+data/engrampa.appdata.xml.in.in
 data/engrampa.desktop.in.in
 data/org.mate.engrampa.gschema.xml.in
 caja/engrampa-module.c

--- a/src/actions.c
+++ b/src/actions.c
@@ -906,7 +906,7 @@ activate_action_about (GtkAction *action,
                    "logo-icon-name", "engrampa",
                    "license", license_text,
                    "wrap-license", TRUE,
-                   "website", "https://mate-desktop.org",
+                   "website", PACKAGE_URL,
                    NULL);
 
     g_strfreev (authors);


### PR DESCRIPTION
Test:
```
$ grep Website caja/libcaja-engrampa.caja-extension
Website=https://mate-desktop.org
$ grep PACKAGE_URL config.h
#define PACKAGE_URL "https://mate-desktop.org"
$ grep homepage data/engrampa.appdata.xml
  <url type="homepage">https://mate-desktop.org</url>
```

- Set all [AC_INIT](https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Initializing-configure.html) fields including optional ones (configure.ac):
```
Macro: AC_INIT (package, version, [bug-report], [tarname], [url])
```

- Do not include the generated files `$(desktop_DATA)`and `$(desktop_in_files)` in `EXTRA_DIST` (data/Makefile.am)
