### PR TITLE
build: display package name and version in configure summary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,10 @@ AC_CONFIG_FILES([Makefile
 AC_OUTPUT
 
 echo "
-Configuration:
+Configure summary:
+
+	${PACKAGE_STRING}
+	`echo $PACKAGE_STRING | sed "s/./=/g"`
 
 	Source code location:   ${srcdir}
 	Compiler:               ${CC}


### PR DESCRIPTION
```
$ ./autogen.sh --prefix=/usr
<cut>
Configure summary:

	engrampa 1.25.0
	===============

	Source code location:   .
	Compiler:               gcc
        Compiler flags:         
        Warning flags:          -Wall -Wmissing-prototypes
        Linker flags:           
	Caja support:           yes
	PackageKit support:     yes
	Run in place            no
	Use libmagic:           no
	JSON support:           yes

Now type `make' to compile engrampa
```