### PR TITLE
build: don't add twice the file engrampa.appdata.xml to CLEANFILES

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -64,7 +64,6 @@ CLEANFILES = \
 	$(appdata_DATA) \
 	$(desktop_DATA) \
 	$(gsettings_SCHEMAS) \
-	engrampa.appdata.xml \
 	$(NULL)
 
 dist-hook:


### PR DESCRIPTION
The variable `appdata_DATA` is set to `engrampa.appdata.xml`