### PR TITLE
build: allow users to disable gettext support (--disable-nls)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,13 +7,17 @@ else
 CAJA =
 endif
 
+if USE_NLS
+PO_SUBDIR = po
+endif
+
 SUBDIRS =		\
 	mate-submodules \
 	data		\
 	src		\
 	help		\
-	$(CAJA)	\
-	po
+	$(CAJA)		\
+	$(PO_SUBDIR)
 
 distcleancheck_listfiles = find . -type f -print | grep -v 'omf\.out'
 

--- a/caja/Makefile.am
+++ b/caja/Makefile.am
@@ -23,7 +23,11 @@ extension_in_in_files = libcaja-engrampa.caja-extension.desktop.in.in
 extension_in_files = $(extension_in_in_files:.caja-extension.desktop.in.in=.caja-extension.desktop.in)
 extension_DATA = $(extension_in_files:.caja-extension.desktop.in=.caja-extension)
 $(extension_DATA): $(extension_in_files)
-	$(AM_V_GEN) $(MSGFMT) --desktop --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+if USE_NLS
+	$(AM_V_GEN) $(MSGFMT) --desktop --keyword= --keyword=Copyright --keyword=Name --keyword=Description --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp -f $< $@
+endif
 
 DISTCLEANFILES = $(extension_in_files)
 CLEANFILES = $(extension_DATA)

--- a/configure.ac
+++ b/configure.ac
@@ -136,9 +136,10 @@ GETTEXT_PACKAGE=AC_PACKAGE_NAME
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE", [GetText Package])
 
+AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT_REQUIRE_VERSION([0.19.8])
-AM_GNU_GETTEXT([external])
+AM_CONDITIONAL([USE_NLS], [test "x${USE_NLS}" = "xyes"])
 
 dnl ******************************
 
@@ -249,14 +250,15 @@ Configure summary:
 	${PACKAGE_STRING}
 	`echo $PACKAGE_STRING | sed "s/./=/g"`
 
-	Source code location:   ${srcdir}
-	Compiler:               ${CC}
-        Compiler flags:         ${CFLAGS}
-        Warning flags:          ${WARN_CFLAGS}
-        Linker flags:           ${LDFLAGS}
-	Caja support:           ${enable_caja_actions}
-	PackageKit support:     ${enable_packagekit}
-	Run in place            ${enable_run_in_place}
-	Use libmagic:           ${enable_magic}
-	JSON support:           ${enable_json_glib}
+	Source code location:      ${srcdir}
+	Compiler:                  ${CC}
+	Compiler flags:            ${CFLAGS}
+	Warning flags:             ${WARN_CFLAGS}
+	Linker flags:              ${LDFLAGS}
+	Caja support:              ${enable_caja_actions}
+	PackageKit support:        ${enable_packagekit}
+	Run in place               ${enable_run_in_place}
+	Use libmagic:              ${enable_magic}
+	JSON support:              ${enable_json_glib}
+	Native Language support:   ${USE_NLS}
 "

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -5,7 +5,11 @@ desktop_in_in_files = engrampa.desktop.in.in
 desktop_in_files = $(desktop_in_in_files:.desktop.in.in=.desktop.in)
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 $(desktop_DATA): $(desktop_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) sed '/^# Translators/d' < $< > $@
+endif
 
 matchdir = $(datadir)/engrampa
 match_DATA = packages.match
@@ -21,7 +25,11 @@ appdata_in_in_files = engrampa.appdata.xml.in.in
 appdata_in_files = $(appdata_in_in_files:.xml.in.in=.xml.in)
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 $(appdata_DATA): $(appdata_in_files)
+if USE_NLS
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
+else
+	$(AM_V_GEN) cp -f $< $@
+endif
 
 gsettingsschema_in_files = org.mate.engrampa.gschema.xml.in
 gsettings_SCHEMAS = $(gsettingsschema_in_files:.xml.in=.xml)

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -10,9 +10,13 @@ HELP_MEDIA = 					\
 	figures/engrampa_uparrow.png
 
 # Add linguas to be ignored, e.g. IGNORE_HELP_LINGUAS = ca de es fr
+if USE_NLS
 IGNORE_HELP_LINGUAS =
 HELP_LINGUAS = $(if $(IGNORE_HELP_LINGUAS), \
 	$(filter-out $(IGNORE_HELP_LINGUAS),$(subst /,,$(dir $(wildcard */*.po)))), \
 	$(subst /,,$(dir $(wildcard */*.po))) )
+else
+HELP_LINGUAS =
+endif
 
 -include $(top_srcdir)/git.mk

--- a/src/dlg-update.c
+++ b/src/dlg-update.c
@@ -21,6 +21,8 @@
  */
 
 #include <config.h>
+#include <glib/gi18n.h>
+
 #include <string.h>
 #include <gtk/gtk.h>
 #include "dlg-update.h"
@@ -119,7 +121,7 @@ update_cb (GtkWidget *widget,
 static void
 update_file_list (DialogData *data)
 {
-	gboolean     n_files;
+	guint        n_files;
 	GList       *scan;
 	GtkTreeIter  iter;
 
@@ -172,10 +174,11 @@ update_file_list (DialogData *data)
 
 		/* secondary text */
 
-		label = g_strdup_printf (ngettext ("The file has been modified with an external application. If you don't update the file in the archive, all of your changes will be lost.",
-						   "%d files have been modified with an external application. If you don't update the files in the archive, all of your changes will be lost.",
-						   n_files),
-					 n_files);
+		label = g_strdup_printf (g_dngettext (GETTEXT_PACKAGE,
+		                                      "The file has been modified with an external application. If you don't update the file in the archive, all of your changes will be lost.",
+		                                      "%u files have been modified with an external application. If you don't update the files in the archive, all of your changes will be lost.",
+		                                      (gulong) n_files),
+		                         n_files);
 		gtk_label_set_text (GTK_LABEL (data->update_file_secondary_text_label), label);
 		g_free (label);
 	}
@@ -200,10 +203,11 @@ update_file_list (DialogData *data)
 
 		/* secondary text */
 
-		label = g_strdup_printf (ngettext ("The file has been modified with an external application. If you don't update the file in the archive, all of your changes will be lost.",
-						   "%d files have been modified with an external application. If you don't update the files in the archive, all of your changes will be lost.",
-						   n_files),
-					 n_files);
+		label = g_strdup_printf (g_dngettext (GETTEXT_PACKAGE,
+		                                      "The file has been modified with an external application. If you don't update the file in the archive, all of your changes will be lost.",
+		                                      "%u files have been modified with an external application. If you don't update the files in the archive, all of your changes will be lost.",
+		                                      (gulong) n_files),
+		                         n_files);
 		gtk_label_set_text (GTK_LABEL (data->update_files_secondary_text_label), label);
 		g_free (label);
 	}

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -1418,8 +1418,10 @@ fr_window_update_statusbar_list_info (FrWindow *window)
 {
 	char    *info, *archive_info, *selected_info;
 	char    *size_txt, *sel_size_txt;
-	int      tot_n, sel_n;
-	goffset  tot_size, sel_size;
+	gulong   tot_n = 0;
+	gulong   sel_n = 0;
+	goffset  tot_size = 0;
+	goffset  sel_size = 0;
 	GList   *scan;
 
 	if (window == NULL)
@@ -1429,9 +1431,6 @@ fr_window_update_statusbar_list_info (FrWindow *window)
 		gtk_statusbar_pop (GTK_STATUSBAR (window->priv->statusbar), window->priv->list_info_cid);
 		return;
 	}
-
-	tot_n = 0;
-	tot_size = 0;
 
 	if (window->priv->archive_present) {
 		GPtrArray *files = fr_window_get_current_dir_list (window);
@@ -1448,9 +1447,6 @@ fr_window_update_statusbar_list_info (FrWindow *window)
 		}
 		g_ptr_array_free (files, TRUE);
 	}
-
-	sel_n = 0;
-	sel_size = 0;
 
 	if (window->priv->archive_present) {
 		GList *selection = get_selection_as_fd (window);
@@ -1471,12 +1467,12 @@ fr_window_update_statusbar_list_info (FrWindow *window)
 	if (tot_n == 0)
 		archive_info = g_strdup ("");
 	else
-		archive_info = g_strdup_printf (ngettext ("%d object (%s)", "%d objects (%s)", tot_n), tot_n, size_txt);
+		archive_info = g_strdup_printf (g_dngettext (GETTEXT_PACKAGE, "%lu object (%s)", "%lu objects (%s)", tot_n), tot_n, size_txt);
 
 	if (sel_n == 0)
 		selected_info = g_strdup ("");
 	else
-		selected_info = g_strdup_printf (ngettext ("%d object selected (%s)", "%d objects selected (%s)", sel_n), sel_n, sel_size_txt);
+		selected_info = g_strdup_printf (g_dngettext (GETTEXT_PACKAGE, "%lu object selected (%s)", "%lu objects selected (%s)", sel_n), sel_n, sel_size_txt);
 
 	info = g_strconcat (archive_info,
 			    ((sel_n == 0) ? NULL : ", "),
@@ -2710,17 +2706,19 @@ fr_window_progress_cb (FrArchive *archive,
 
 		if ((archive != NULL) && (archive->command != NULL) && (archive->command->n_files > 0)) {
 			char *message = NULL;
-			int   remaining_files;
+			gulong remaining_files;
 
-			remaining_files = archive->command->n_files - archive->command->n_file + 1;
+			remaining_files = (gulong) (archive->command->n_files - archive->command->n_file + 1);
 
 			switch (window->priv->action) {
 			case FR_ACTION_ADDING_FILES:
 			case FR_ACTION_EXTRACTING_FILES:
 			case FR_ACTION_DELETING_FILES:
-				message = g_strdup_printf (ngettext ("%d file remaining",
-								     "%d files remaining",
-								     remaining_files), remaining_files);
+				message = g_strdup_printf (g_dngettext (GETTEXT_PACKAGE,
+				                                        "%lu file remaining",
+				                                        "%lu files remaining",
+			                                                remaining_files),
+				                           remaining_files);
 				break;
 			default:
 				break;

--- a/src/main.c
+++ b/src/main.c
@@ -317,12 +317,16 @@ main (int argc, char **argv)
 
 	program_argv0 = argv[0];
 
+#ifdef ENABLE_NLS
 	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	context = g_option_context_new (N_("- Create and modify an archive"));
+#ifdef ENABLE_NLS
 	g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 	g_option_context_add_main_entries (context, options, GETTEXT_PACKAGE);
 
 	g_option_context_add_group (context, gtk_get_option_group (TRUE));

--- a/src/server.c
+++ b/src/server.c
@@ -437,12 +437,16 @@ main (int argc, char *argv[])
 	GError         *error = NULL;
 	guint           owner_id;
 
+#ifdef ENABLE_NLS
 	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 
 	context = g_option_context_new (N_("- Create and modify an archive"));
+#ifdef ENABLE_NLS
 	g_option_context_set_translation_domain (context, GETTEXT_PACKAGE);
+#endif /* ENABLE_NLS */
 	g_option_context_add_group (context, gtk_get_option_group (TRUE));
 
 	if (! g_option_context_parse (context, &argc, &argv, &error)) {


### PR DESCRIPTION
### With NLS
```
$ find /usr/share/locale -type f -name 'engrampa.mo' -exec sudo rm -f {} +
$ find /usr/share/help -type d -name 'engrampa' -exec sudo rm -fr {} +
$ ./autogen.sh --prefix=/usr && make && sudo make install
$ find /usr/share/locale -type f -name 'engrampa.mo' -exec du -ch {} + | grep total
2,9M	total
$ find /usr/share/help -type d -name 'engrampa' -exec du -ch {} + | grep total
12M	total
```
### Without NLS
```
$ find /usr/share/locale -type f -name 'engrampa.mo' -exec sudo rm -f {} +
$ find /usr/share/help -type d -name 'engrampa' -exec sudo rm -fr {} +
$ ./autogen.sh --prefix=/usr --disable-nls && make && sudo make install
$ find /usr/share/locale -type f -name 'engrampa.mo' -exec du -ch {} + | grep total
$ find /usr/share/help -type d -name 'engrampa' -exec du -ch {} + | grep total
136K	total
```
