### PR TITLE
ar format: Handle the case where ar lists files with single-digit dates

### DIFF
--- a/src/fr-command-ar.c
+++ b/src/fr-command-ar.c
@@ -70,7 +70,7 @@ ar_get_last_field (const char *line,
 	f_end = f_start;
 
 	while ((field_n > 0) && (*f_end != 0)) {
-		if (*f_end == ' ') {
+		if (*f_end == ' ' && *(f_end-1) != ' ') {
 			field_n--;
 			if (field_n == 1)
 				f_start = f_end;


### PR DESCRIPTION
A function for finding the start of the archive member's name used to
consider two spaces in a row to mean two "fields" in the formatted date
string produced by ar.  This led to pathnames errantly containing the
year the file was created.  This commit considers double spaces to mean
the same thing that single spaces mean.