### PR TITLE
equality comparison with extraneous parentheses

### DIFF
--- a/src/fr-command-alz.c
+++ b/src/fr-command-alz.c
@@ -289,7 +289,7 @@ static void
 fr_command_alz_handle_error (FrCommand   *comm,
 			     FrProcError *error)
 {
-	if ((error->type == FR_PROC_ERROR_STOPPED)) {
+	if (error->type == FR_PROC_ERROR_STOPPED) {
 		if  (FR_COMMAND_ALZ (comm)->extract_none ||
 		     FR_COMMAND_ALZ (comm)->invalid_password ) {
 			error->type = FR_PROC_ERROR_ASK_PASSWORD;


### PR DESCRIPTION
```
fr-command-alz.c:292:19: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
        if ((error->type == FR_PROC_ERROR_STOPPED)) {
             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
fr-command-alz.c:292:19: note: remove extraneous parentheses around the comparison to silence this warning
```