### PR TITLE
glib-utils: escape_str_common should be static

### DIFF
--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -118,7 +118,7 @@ count_chars_to_escape (const char *str,
 	return n;
 }
 
-char*
+static char*
 escape_str_common (const char *str,
 		   const char *meta_chars,
 		   const char  prefix,

--- a/src/glib-utils.h
+++ b/src/glib-utils.h
@@ -41,10 +41,6 @@ char *              str_substitute               (const char *str,
 						  const char *from_str,
 						  const char *to_str);
 int                 strcmp_null_tolerant         (const char *s1, const char *s2);
-char*               escape_str_common            (const char *str,
-						  const char *meta_chars,
-						  const char  prefix,
-						  const char  postfix);
 char*               escape_str                   (const char  *str,
 						  const char  *meta_chars);
 gboolean            match_regexps                (GRegex     **regexps,


### PR DESCRIPTION
The function is only used in escape_str_common.c and it's called after its implementation.