### PR TITLE
Fix build warnings about missing field initializer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -89,7 +89,7 @@ static const GOptionEntry options[] = {
 	  NULL,
 	  NULL },
 
-	{ NULL }
+	{ NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
 
 static void

--- a/src/server.c
+++ b/src/server.c
@@ -383,7 +383,8 @@ handle_method_call (GDBusConnection       *connection,
 static const GDBusInterfaceVTable interface_vtable = {
 	handle_method_call,
 	NULL, 			/* handle_get_property */
-	NULL 			/* handle_set_property */
+	NULL, 			/* handle_set_property */
+	{ 0 }
 };
 
 static void


### PR DESCRIPTION
```
main.c:92:9: warning: missing field 'short_name' initializer [-Wmissing-field-initializers]
        { NULL }
               ^
--
server.c:393:1: warning: missing field 'padding' initializer [-Wmissing-field-initializers]
};
^
```