### PR TITLE
Fix implicit conversion changes signedness: 'gboolean'

### DIFF
--- a/src/fr-process.c
+++ b/src/fr-process.c
@@ -413,7 +413,7 @@ fr_process_set_sticky (FrProcess *process,
 	g_return_if_fail (process->priv->current_comm >= 0);
 
 	info = g_ptr_array_index (process->priv->comm, process->priv->current_comm);
-	info->sticky = sticky;
+	info->sticky = (sticky != FALSE);
 }
 
 void
@@ -426,7 +426,7 @@ fr_process_set_ignore_error (FrProcess *process,
 	g_return_if_fail (process->priv->current_comm >= 0);
 
 	info = g_ptr_array_index (process->priv->comm, process->priv->current_comm);
-	info->ignore_error = ignore_error;
+	info->ignore_error = (ignore_error != FALSE);
 }
 
 void

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -6421,7 +6421,7 @@ archive_is_encrypted (FrWindow *window,
 void
 fr_window_archive_extract_here (FrWindow   *window,
 				gboolean    skip_older,
-				gboolean    overwrite,
+				FrOverwrite overwrite,
 				gboolean    junk_paths)
 {
 	ExtractData *edata;
@@ -8538,7 +8538,7 @@ fr_window_exec_batch_action (FrWindow      *window,
 
 		fr_window_archive_extract_here (window,
 						FALSE,
-						TRUE,
+						FR_OVERWRITE_NO,
 						FALSE);
 		break;
 

--- a/src/fr-window.h
+++ b/src/fr-window.h
@@ -158,7 +158,7 @@ void        fr_window_archive_extract           (FrWindow      *window,
 						 gboolean       ask_to_open_destination);
 void        fr_window_archive_extract_here      (FrWindow      *window,
 						 gboolean       skip_older,
-						 gboolean       overwrite,
+						 FrOverwrite    overwrite,
 						 gboolean       junk_paths);
 void        fr_window_archive_test	        (FrWindow      *window);
 


### PR DESCRIPTION
```
git submodule init
git submodule update --recursive --remote
CFLAGS="-Wconversion -Wunused-macros -Wunused-parameter" CC=clang ./autogen.sh --prefix=/usr --enable-debug --enable-compile-warnings=maximum && make &> make.log
```
```
fr-process.c:416:17: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        info->sticky = sticky;
                     ~ ^~~~~~
fr-process.c:429:23: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'guint' (aka 'unsigned int') [-Wsign-conversion]
        info->ignore_error = ignore_error;
                           ~ ^~~~~~~~~~~~
--
fr-window.c:6433:7: warning: implicit conversion changes signedness: 'gboolean' (aka 'int') to 'FrOverwrite' [-Wsign-conversion]
                                  overwrite,
                                  ^~~~~~~~~
```