### PR TITLE
Add .pkg support for FreeBSD

### DIFF
--- a/src/fr-init.c
+++ b/src/fr-init.c
@@ -150,6 +150,7 @@ FrExtensionType file_ext_type[] = {
 	{ ".otp", "application/vnd.oasis.opendocument.presentation-template" },
 	{ ".ots", "application/vnd.oasis.opendocument.spreadsheet-template" },
 	{ ".ott", "application/vnd.oasis.opendocument.text-template" },
+	{ ".pkg", "application/x-xz-compressed-tar" },
 	{ ".rar", "application/x-rar" },
 	{ ".rpm", "application/x-rpm" },
 	{ ".rz", "application/x-rzip" },


### PR DESCRIPTION
Freebsd has recently changed the extension of its packages [1], so it is necessary to add the .pkg extension in order to open them with engrampa.

[1] https://cgit.freebsd.org/ports/commit/?id=e497a16a286972bfcab908209b11ee6a13d99dc9