### PR TITLE
glib-utils: redundant condition

### DIFF
--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -363,7 +363,7 @@ eat_spaces (const char *line)
 {
 	if (line == NULL)
 		return NULL;
-	while ((*line == ' ') && (*line != 0))
+	while (*line == ' ')
 		line++;
 	return line;
 }


### PR DESCRIPTION
```
$ cppcheck --enable=all --quiet . &> cppcheck.log
$ grep -A 2 redundantCondition cppcheck.log 
src/glib-utils.c:366:24: style: Redundant condition: If 'EXPR == ' '', the comparison 'EXPR != 0' is always true. [redundantCondition]
 while ((*line == ' ') && (*line != 0))
                       ^
```