### PR TITLE
fr-window: fix -Wincompatible-pointer-types warning

### DIFF
--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -5776,7 +5776,7 @@ fr_window_construct (FrWindow *window)
 	gtk_entry_set_icon_from_icon_name (GTK_ENTRY (window->priv->location_entry),
 				       GTK_ENTRY_ICON_PRIMARY,
 				       "folder");
-	gtk_label_set_mnemonic_widget (window->priv->location_label,
+	gtk_label_set_mnemonic_widget (GTK_LABEL (window->priv->location_label),
 				       window->priv->location_entry);
 
 	gtk_box_pack_start (GTK_BOX (location_box),


### PR DESCRIPTION
```
fr-window.c:5779:33: warning: incompatible pointer types passing 'GtkWidget *' (aka 'struct _GtkWidget *') to parameter of type 'GtkLabel *' (aka 'struct _GtkLabel *') [-Wincompatible-pointer-types]
        gtk_label_set_mnemonic_widget (window->priv->location_label,
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/gtk-3.0/gtk/gtklabel.h:129:70: note: passing argument to parameter 'label' here
void     gtk_label_set_mnemonic_widget            (GtkLabel         *label,
                                                                     ^
```