### PR TITLE
Fix archive file save as function

### DIFF
--- a/src/actions.c
+++ b/src/actions.c
@@ -198,6 +198,22 @@ get_archive_filename_from_selector (DlgNewData *data)
     }
     g_object_unref (info);
     g_object_unref (dir);
+    if ((data->original_file != NULL) && (g_file_equal (file, data->original_file))) {
+        GtkWidget *dialog;
+        dialog = _gtk_error_dialog_new (GTK_WINDOW (data->dialog),
+                        GTK_DIALOG_MODAL,
+                        NULL,
+                        _("Could not create the archive"),
+                        "%s",
+                        _("New name is the same as old one, please type other name."));
+        gtk_dialog_run (GTK_DIALOG (dialog));
+
+        gtk_widget_destroy (GTK_WIDGET (dialog));
+        g_object_unref (info);
+        g_object_unref (file);
+
+        return NULL;
+    }
 
     /* if the user did not specify a valid extension use the filetype combobox current type
      * or tar.gz if automatic is selected. */
@@ -450,11 +466,11 @@ activate_action_save_as (GtkAction *action,
 {
     FrWindow   *window = callback_data;
     DlgNewData *data;
+    GFile      *file = NULL;
     char       *archive_name = NULL;
 
     if (fr_window_get_archive_uri (window)) {
         const char *uri;
-        GFile      *file;
         GFileInfo  *info;
         GError     *err = NULL;
 
@@ -472,10 +488,10 @@ activate_action_save_as (GtkAction *action,
             archive_name = g_strdup (g_file_info_get_display_name (info));
 
         g_object_unref (info);
-        g_object_unref (file);
     }
 
     data = dlg_save_as (window, archive_name);
+    data->original_file = file;
     g_signal_connect (G_OBJECT (data->dialog),
               "response",
               G_CALLBACK (save_file_response_cb),

--- a/src/dlg-new.c
+++ b/src/dlg-new.c
@@ -40,6 +40,8 @@ static void
 destroy_cb (GtkWidget  *widget,
 	    DlgNewData *data)
 {
+	if (data->original_file != NULL)
+		g_object_unref (data->original_file);
 	g_free (data);
 }
 

--- a/src/dlg-new.h
+++ b/src/dlg-new.h
@@ -35,6 +35,7 @@ typedef struct {
 	gboolean    can_create_volumes;
 	GtkBuilder *builder;
 
+	GFile      *original_file;
 	GtkWidget  *dialog;
 	/*GtkWidget  *n_archive_type_combo_box;*/
 	GtkWidget  *n_other_options_expander;

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -6171,8 +6171,8 @@ fr_window_archive_save_as (FrWindow   *window,
 				     NULL,
 				     window->priv->convert_data.temp_dir,
 				     NULL,
-				     TRUE,
 				     FALSE,
+				     TRUE,
 				     FALSE,
 				     window->priv->password);
 	fr_process_start (window->archive->process);


### PR DESCRIPTION
Fix archive file save as functio. When saving as, it will check whether the two archive files are the same

#414 