### PR TITLE
file-utils: Include <strings.h> for strcasecmp

### DIFF
--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
The _XOPEN_SOURCE macro definition overrides _DEFAULT_SOURCE and disables the declaration in <string.h>.

This avoids an implicit function declaration and build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
