### PR TITLE
Fix failure to extract multiple files

### DIFF
--- a/src/glib-utils.c
+++ b/src/glib-utils.c
@@ -510,6 +510,9 @@ _g_path_get_base_name (const char *path,
 	if (junk_paths)
 		return _g_path_get_file_name (path);
 
+	if (base_dir == NULL)
+		return (path[0] == '/') ? path + 1 : path;
+
 	base_dir_len = strlen (base_dir);
 	if (strlen (path) < base_dir_len)
 		return NULL;


### PR DESCRIPTION

[05-13-2023Screen video05^%41^%24 PM.webm](https://github.com/mate-desktop/engrampa/assets/36913152/c2b8e2cc-fe05-4fe0-9d04-0b64d1975ed9)
Fix failure to extract multiple files
Fix #371 

## test
```
mkdir /tmp/test
cd /tmp/test
touch test{1,2,3}.file
find -type f -name test"*"file -execdir tar -zcvf '{}.tar.gz' '{}' \; | xargs rm -rf
engrampa -f *.gz
```
