### PR TITLE
Archive: do not track symbolic link

### DIFF
--- a/src/gio-utils.h
+++ b/src/gio-utils.h
@@ -38,8 +38,9 @@ typedef DirOp (*StartDirCallback)    (const char  *uri,
 				      GError     **error,
 				      gpointer     user_data);
 typedef void (*ForEachChildCallback) (const char  *uri,
-				      GFileInfo   *info,
-				      gpointer     user_data);
+				       gboolean     follow_links,
+				       GFileInfo   *info,
+				       gpointer     user_data);
 typedef void (*ForEachDoneCallback)  (GError      *error,
 				      gpointer     data);
 typedef void (*ListReadyCallback)    (GList       *files,


### PR DESCRIPTION
```g_file_enumerate_children_async``` default should use ```G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS```. This can avoid link loops
Fix #254 
## test
```
mkdir /tmp/test
cd /tmp/test
for x in $( seq 1 1000 ); do mkdir test${x}; touch test${x}/${x}; done
mkdir test1001
cd test1001
ln -s ../ new
engrampa -d /tmp/test
```
The number of archived files should be 2003