### PR TITLE
Uniform file chooser dialog margin size

### DIFF
--- a/src/ui/new.ui
+++ b/src/ui/new.ui
@@ -213,7 +213,6 @@
   </object>
   <object class="GtkFileChooserDialog" id="dialog">
     <property name="can_focus">False</property>
-    <property name="border_width">5</property>
     <property name="modal">True</property>
     <property name="window_position">center-on-parent</property>
     <property name="type_hint">normal</property>


### PR DESCRIPTION
The file chooser dialog margin size should remain the same， Open、New、Extract
Fix #184  