### PR TITLE
Fix failed restore of saved sessions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -284,7 +284,7 @@ fr_save_state (EggSMClient *client, GKeyFile *state, gpointer user_data)
 			FrWindow *session = window->data;
 			gchar *key;
 
-			key = g_strdup_printf ("archive%d", i);
+			key = g_strdup_printf ("archive%d", i+1);
 			if ((session->archive == NULL) || (session->archive->file == NULL)) {
 				g_key_file_set_string (state, "Session", key, "");
 			}


### PR DESCRIPTION
Fix #245
```
[Session]
archive0=file:///tmp/ssss.7z
archives=1
```
```
    i = g_key_file_get_integer (state, "Session", "archives", NULL); = 1;

    for (; i > 0; i--) {
        key = g_strdup_printf ("archive%d", i) = "archive1";
        archive = g_key_file_get_string (state, "Session", "archive1", NULL) = NULL;
        g_free (key);
        if (strlen (archive)) /*strlen (NULL)*/
            fr_window_archive_open (FR_WINDOW (window), archive, GTK_WINDOW (window));
    }
```
This can cause memory crash
