### PR TITLE
Fixed libmagic bug 

### DIFF
--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -1102,7 +1102,12 @@ load_local_archive (FrArchive  *archive,
 
 	old_command = archive->command;
 
-	mime_type = get_mime_type_from_filename (archive->local_copy);
+	if ENABLE_MAGIC
+		mime_type = get_mime_type_from_magic_numbers (archive->local_copy);
+	else
+ 		mime_type = get_mime_type_from_filename (archive->local_copy);
+	endif
+
 	if (! create_command_to_load_archive (archive, mime_type)) {
 		mime_type = get_mime_type_from_content (archive->local_copy);
 		if (! create_command_to_load_archive (archive, mime_type)) {


### PR DESCRIPTION
Referring to issue #206 , Engrampa uses Libmagic only if extension is not known, otherwise it determines mime type from the file extension, even though the `--enable-magic` flag is used, along with libmagic support.
This pull request adds an if condition to use libmagic if `--enable-magic` if used.