### PR TITLE
Fixed libmagic bug

### DIFF
--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -555,7 +555,7 @@ gboolean
 is_mime_type (const char *mime_type,
 	      const char *pattern)
 {
-	return (strcasecmp (mime_type, pattern) == 0);
+	return g_content_type_equals (mime_type, pattern);
 }
 
 const char*

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -1102,7 +1102,12 @@ load_local_archive (FrArchive  *archive,
 
 	old_command = archive->command;
 
-	mime_type = get_mime_type_from_filename (archive->local_copy);
+#if ENABLE_MAGIC
+	mime_type = get_mime_type_from_magic_numbers (archive->local_copy);
+#else
+ 	mime_type = get_mime_type_from_filename (archive->local_copy);
+#endif
+
 	if (! create_command_to_load_archive (archive, mime_type)) {
 		mime_type = get_mime_type_from_content (archive->local_copy);
 		if (! create_command_to_load_archive (archive, mime_type)) {

--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -1103,9 +1103,9 @@ load_local_archive (FrArchive  *archive,
 	old_command = archive->command;
 
 #if ENABLE_MAGIC
-	mime_type = get_mime_type_from_magic_numbers (archive->local_copy);
-#else
  	mime_type = get_mime_type_from_filename (archive->local_copy);
+#else
+	mime_type = get_mime_type_from_magic_numbers (archive->local_copy);
 #endif
 
 	if (! create_command_to_load_archive (archive, mime_type)) {

--- a/src/fr-init.c
+++ b/src/fr-init.c
@@ -292,7 +292,7 @@ fr_registered_command_get_capabilities (FrRegisteredCommand *reg_com,
 		FrMimeTypeCap *cap;
 
 		cap = g_ptr_array_index (reg_com->caps, i);
-		if (strcmp (mime_type, cap->mime_type) == 0)
+		if (is_mime_type (mime_type, cap->mime_type))
 			return cap->current_capabilities;
 	}
 
@@ -312,7 +312,7 @@ fr_registered_command_get_potential_capabilities (FrRegisteredCommand *reg_com,
 		FrMimeTypeCap *cap;
 
 		cap = g_ptr_array_index (reg_com->caps, i);
-		if ((cap->mime_type != NULL) && (strcmp (mime_type, cap->mime_type) == 0))
+		if ((cap->mime_type != NULL) && (is_mime_type (mime_type, cap->mime_type)))
 			return cap->potential_capabilities;
 	}
 
@@ -508,7 +508,7 @@ get_mime_type_index (const char *mime_type)
 	int i;
 
 	for (i = 0; mime_type_desc[i].mime_type != NULL; i++)
-		if (strcmp (mime_type_desc[i].mime_type, mime_type) == 0)
+		if (is_mime_type (mime_type_desc[i].mime_type, mime_type))
 			return i;
 	return -1;
 }


### PR DESCRIPTION
Referring to issue https://github.com/mate-desktop/engrampa/issues/206 , Engrampa uses Libmagic only if extension is not known, otherwise it determines mime type from the file extension, even though the `--enable-magic` flag is used, along with `libmagic` support.
This pull request adds an if condition to use `libmagic` if `--enable-magic` if used.