### PR TITLE
Fix MIME detection logic from #490

### DIFF
--- a/src/fr-archive.c
+++ b/src/fr-archive.c
@@ -1102,16 +1102,22 @@ load_local_archive (FrArchive  *archive,
 
 	old_command = archive->command;
 
+	/* With libmagic, give priority to magic match, and fall back on filename
+	 * match.  Do it the other way around if we don't have libmagic. */
 #if ENABLE_MAGIC
- 	mime_type = get_mime_type_from_filename (archive->local_copy);
-#else
 	mime_type = get_mime_type_from_magic_numbers (archive->local_copy);
+#else
+	mime_type = get_mime_type_from_filename (archive->local_copy);
 #endif
 
 	if (! create_command_to_load_archive (archive, mime_type)) {
 		mime_type = get_mime_type_from_content (archive->local_copy);
 		if (! create_command_to_load_archive (archive, mime_type)) {
+#if ENABLE_MAGIC
+			mime_type = get_mime_type_from_filename (archive->local_copy);
+#else
 			mime_type = get_mime_type_from_magic_numbers (archive->local_copy);
+#endif
 			if (! create_command_to_load_archive (archive, mime_type)) {
 				archive->command = old_command;
 				archive->content_type = mime_type;


### PR DESCRIPTION
A blooper has been made there:

* if ENABLE_MIME is set, the intention was to try, in order: magic, content, filename; but it was made filename, content, magic (which was the same as before the changes);
* if ENABLE_MIME is not set, the intention was to try, in order: filename, content, magic; but it has been made magic, content, magic (notice the duplicate, and the missing "filename").

This probably doesn't change much in the wild as magic is gonna work most of the time, but it's especially problematic that the non-libmagic case doesn't have the filename test.

Anyway, fix this so the code is consistent, and we retain the behavior for the non-libmagic case, and have the new expected one for the libmagic case.

CC @sinha-toyeesh 