### PR TITLE
7z: Fix accepting RAR archives when unar-open-zip=true

### DIFF
--- a/src/fr-command-7z.c
+++ b/src/fr-command-7z.c
@@ -609,7 +609,7 @@ fr_command_7z_get_mime_types (FrCommand *comm)
 
 	if (g_settings_get_boolean (settings, "unar-open-zip") &&
 	    is_program_in_path ("unar") && is_program_in_path ("lsar"))
-		sevenz_mime_types [8] = NULL;
+		sevenz_mime_types [9] = NULL;
 	else
 		g_settings_set_boolean (settings, "unar-open-zip", FALSE);
 


### PR DESCRIPTION
Offset was not properly updated when adding support for EPUB+ZIP in 84fb5cfe96263f79e50b68a5a6996e40c514cf74, leading to disabling both ZIP and RAR when the option unar-open-zip was enabled.

One can test with:
* One of the supported `7z` available (ideally with RAR support, but the error message itself is enough to see the difference)
* No (`un`)`rar` available (as it takes precedence)
* `unar` and `lsar` available (Debian package `unar`)
* Setting `gsettings set org.mate.engrampa.general unar-open-zip true`
* This patch (because if `unar` can take over it's tricky to tell):
  ```diff
  diff --git a/src/fr-command-unarchiver.c b/src/fr-command-unarchiver.c
  index c7aa5e6..0d3cf53 100644
  --- a/src/fr-command-unarchiver.c
  +++ b/src/fr-command-unarchiver.c
  @@ -246,7 +246,7 @@ fr_command_unarchiver_handle_error (FrCommand   *comm,
   
   const char *unarchiver_mime_type[] = { "application/zip",
   				       "application/x-cbr",
  -				       "application/x-rar",
  +				       //"application/x-rar",
   				       NULL };
   
   static const char **
  ```
* a RAR file (which is trickier than expected to make, so one could use something from [RAR-test-files](https://github.com/ssokolow/rar-test-files/tree/master/build), ideally one of the RAR3 ones for wider support)

Expected: the `org.mate.engrampa.general unar-open-zip` setting has no effect on RAR files.
Actual: It does have an effect.

This is probably actually pretty low impact as it seems the condition can only happen if another RAR-capable backend is available, but that's mostly by chance, and I didn't actually check whether `unar` works with RAR files if there's not (`un`)`rar` versions available.