### PR TITLE
rar: Add support for unrar-free (and related fixes)

### DIFF
--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -229,29 +229,19 @@ process_line (char     *line,
 	if (! rar_comm->rar4_odd_line) {
 		FileData   *fdata;
 		const char *size_field, *ratio_field, *date_field, *time_field, *attr_field;
+		int n_fields;
+
+		if (rar_comm->rar5)
+			n_fields = 6 + (attribute_field_with_space (line) != 0);
+		else
+			n_fields = 6;
 
 		fdata = rar_comm->fdata;
 
 		/* read file info. */
 
-		fields = split_line (line, attribute_field_with_space (line) ? 7 : 6);
-		if (rar_comm->rar5) {
-			int offset = attribute_field_with_space (line) ? 1 : 0;
-
-			size_field = fields[1+offset];
-			ratio_field = fields[3+offset];
-			date_field = fields[4+offset];
-			time_field = fields[5+offset];
-			attr_field = fields[0+offset];
-		}
-		else {
-			size_field = fields[0];
-			ratio_field = fields[2];
-			date_field = fields[3];
-			time_field = fields[4];
-			attr_field = fields[5];
-		}
-		if (g_strv_length (fields) < 6) {
+		fields = split_line (line, n_fields);
+		if (g_strv_length (fields) < (guint) n_fields) {
 			/* wrong line format, treat this line as a filename line */
 			g_strfreev (fields);
 			file_data_free (rar_comm->fdata);
@@ -260,6 +250,23 @@ process_line (char     *line,
 			parse_name_field (line, rar_comm);
 		}
 		else {
+			if (rar_comm->rar5) {
+				int offset = attribute_field_with_space (line) ? 1 : 0;
+
+				size_field = fields[1+offset];
+				ratio_field = fields[3+offset];
+				date_field = fields[4+offset];
+				time_field = fields[5+offset];
+				attr_field = fields[0+offset];
+			}
+			else {
+				size_field = fields[0];
+				ratio_field = fields[2];
+				date_field = fields[3];
+				time_field = fields[4];
+				attr_field = fields[5];
+			}
+
 			if ((strcmp (ratio_field, "<->") == 0)
 			    || (strcmp (ratio_field, "<--") == 0))
 			{

--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -194,35 +194,19 @@ process_line (char     *line,
 	g_return_if_fail (line != NULL);
 
 	if (! rar_comm->list_started) {
-		if (strncmp (line, "RAR ", 4) == 0) {
-			int version;
-			sscanf (line, "RAR %d.", &version);
+		int version = 0;
+
+		if (sscanf (line, "RAR %d.", &version) == 1 || sscanf (line, "UNRAR %d.", &version) == 1) {
 			rar_comm->rar5 = (version >= 5);
 
 			if (version > 5)
 				date_newstyle = TRUE;
-			else if (version == 5)
+			else if (version == 5 && (sscanf (line, "RAR 5.%d ", &version) == 1 ||
+			                          sscanf (line, "UNRAR 5.%d ", &version) == 1))
 			{
-				sscanf (line, "RAR 5.%d ", &version);
 				if (version >= 30)
 					date_newstyle = TRUE;
 			}
-
-		}
-		else if (strncmp (line, "UNRAR ", 6) == 0) {
-			int version;
-			sscanf (line, "UNRAR %d.", &version);
-			rar_comm->rar5 = (version >= 5);
-
-			if (version > 5)
-				date_newstyle = TRUE;
-			else if (version == 5)
-			{
-				sscanf (line, "UNRAR 5.%d ", &version);
-				if (version >= 30)
-					date_newstyle = TRUE;
-			}
-
 		}
 		else if (strncmp (line, "--------", 8) == 0) {
 			rar_comm->list_started = TRUE;

--- a/src/fr-command-rar.h
+++ b/src/fr-command-rar.h
@@ -38,13 +38,20 @@
 typedef struct _FrCommandRar       FrCommandRar;
 typedef struct _FrCommandRarClass  FrCommandRarClass;
 
+typedef enum
+{
+	FR_COMMAND_RAR_TYPE_RAR4 = 0,
+	FR_COMMAND_RAR_TYPE_RAR5,
+	FR_COMMAND_RAR_TYPE_UNRAR_FREE,
+} FrCommandRarType;
+
 struct _FrCommandRar
 {
 	FrCommand  __parent;
 
 	gboolean  list_started;
 	gboolean  rar4_odd_line;
-	gboolean  rar5;
+	FrCommandRarType output_type;
 	FileData *fdata;
 };
 


### PR DESCRIPTION
This adds support for `unrar-free` as the `unrar` implementation.  Without this, at least for me on Debian with unrar-free 0.1.3, RAR archives open empty ***[edit]** while on non-Debian, unrar-free is just not used*.

There are 2 seemingly unrelated commits, but they actually change required things for the third commit to work (I could do it differently, but it'd be more messy):
* [rar: Simplify and merge duplicate code](https://github.com/mate-desktop/engrampa/commit/0d809c8d2ccb311fd51dcfddaeb8eced8b3df223) as stated in the commit message, we need the more strict RAR version matching not to erroneously match unrar-free output (which would prevent recognizing it is unrar-free, as well as reading an uninitialized variable)
* [rar: Fix out of bounds read on malformed output](https://github.com/mate-desktop/engrampa/commit/d806ca9252532a9efe6b2d6568bee39446da3cc5) this is more subtle why it's needed: the thing is that `split_line()` it arguably buggy when it comes to the last field, and will only parse the last field on the line if it's exactly the last one we asked for.  This means we need to really pass the amount we expect and not more, so code had to be adjusted.  It was easier to fix the out of bounds read *before* adding a third possible value.

When merging I'd rather *not* squash the commits as they the unrar-free part is otherwise unrelated to the other 2; another option would be to first make a PR for the 2 fixes, and only then a second one for the unrar-free part.  I can do if you prefer, but I feel like it's a bit artificial, unless you tell me only part of it is acceptable, or that it's easier to review separately (which would if it was a bigger change).

If you don't have RAR test files, you can give [RAR-test-files](https://github.com/ssokolow/rar-test-files/tree/master/build) a spin.

:warning: **DISCLAIMER** :warning: I did **NOT** test this with the actual non-free `rar` and `unrar`.  Behavior *should* be the same (I tried to be careful), but I did not test with the actual programs.
What I **did** however is create a mock `rar` in my path that outputs one of the sample outputs found in `fr-command-rar.c`, and so I tried the 3 versions both as `RAR` and `UNRAR`.  That worked nicely, but that's only worth what a mock is worth.