### PR TITLE
zip: Fix crashes on buggy zip output

### DIFF
--- a/src/fr-command-zip.c
+++ b/src/fr-command-zip.c
@@ -59,6 +59,10 @@ mktime_from_string (char *datetime_s)
 	char      *min;
 	char      *sec;
 
+	/* expected YYYYMMDD.HHMMSS */
+	if (strlen (datetime_s) < 15)
+		return mktime (&tm);
+
 	tm.tm_isdst = -1;
 
 	/* date */
@@ -124,9 +128,14 @@ list__process_line (char     *line,
 
 	/**/
 
+	fields = split_line (line, 7);
+	if (g_strv_length (fields) < 7) {
+		g_strfreev (fields);
+		return;
+	}
+
 	fdata = file_data_new ();
 
-	fields = split_line (line, 7);
 	fdata->size = g_ascii_strtoull (fields[3], NULL, 10);
 	fdata->modified = mktime_from_string (fields[6]);
 	fdata->encrypted = (*fields[4] == 'B') || (*fields[4] == 'T');
@@ -135,6 +144,8 @@ list__process_line (char     *line,
 	/* Full path */
 
 	name_field = get_last_field (line, 8);
+	if (name_field == NULL)
+		name_field = "";
 
 	if (*name_field == '/') {
 		fdata->full_path = g_strdup (name_field);


### PR DESCRIPTION
Fix crash if the `zip` command emits a line starting with one of 'd?-' yet having less than 8 fields in it, or if the date field is malformed.

Small fixed for not doing nasty things if `unzip` doesn't output what we expect.

## Testing

Real test should be that it doesn't break anything, as that's what most important (although it's unused for people having one of the 7z, which is used in priority)

Convoluted test is to check what happens with random unexpected output from unzip.

What I did to test unexpected output was add a dummy `unzip` to my PATH, and get that to emit output good enough for the code to try and parse it, and bad enough to trigger issues.
For example, use this script in your PATH:
<details>
<summary><code>~/.local/bin/unzip</code></summary>

```shell
#!/bin/sh

cat << EOF
# legit stuff
? x x 123 A X 20240123.223500 foo1
d x x 456 B X 20240123.223600 foo2
- x x 789 C X 20240123.223789 foo3
# less legit stuff
? foo4
? x x 789 C X x foo5
# more legit stuff to make sure we keep on reading
- x x 789 C X 20240123.223789 foo6
EOF
```

</details>

You also need not to have any 7z, or disable ZIP handling by 7z as it takes precedence:
```diff
diff --git a/src/fr-command-7z.c b/src/fr-command-7z.c
index 7b40d5e..5d385a3 100644
--- a/src/fr-command-7z.c
+++ b/src/fr-command-7z.c
@@ -598,7 +598,7 @@ const char *sevenz_mime_types[] = { "application/epub+zip",
 				    "application/x-ms-dos-executable",
 				    "application/x-ms-wim",
 				    "application/x-rar",
-				    "application/zip", /* zip always at the end and the number of */
+				    //"application/zip", /* zip always at the end and the number of */
 				    NULL };            /* place in fr_command_7z_get_mime_types   */
 
 static const char **
```

Normally this should result in a clean Valgrind report (well, for memory errors that is, there's probably a lot of unrelated leaks to be found).