### PR TITLE
src/file-utils.c: Fix "error: implicit declaration of function ‘strca…

### DIFF
--- a/src/file-utils.c
+++ b/src/file-utils.c
@@ -31,6 +31,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <unistd.h>
+#include <strings.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/time.h>


### PR DESCRIPTION
…secmp’ [-Werror=implicit-function-declaration]".