### PR TITLE
Fix spinbox for creating split archives of set filesize

### DIFF
--- a/src/ui/batch-add-files.ui
+++ b/src/ui/batch-add-files.ui
@@ -18,8 +18,10 @@
     <property name="icon_name">help-browser</property>
   </object>
   <object class="GtkAdjustment" id="volume_adjustment">
-    <property name="upper">9999999999</property>
+    <property name="lower">0.10000000000000001</property>
+    <property name="upper">10000</property>
     <property name="value">10</property>
+    <property name="step_increment">0.10000000000000001</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkDialog" id="dialog">


### PR DESCRIPTION
*Based on patch by Yaroslav Kokurin , max per-archive size increased to 10GB