### PR TITLE
rar: Fix asking password for encrypted archives with RAR7

### DIFF
--- a/src/fr-command-rar.c
+++ b/src/fr-command-rar.c
@@ -697,7 +697,12 @@ fr_command_rar_handle_error (FrCommand   *comm,
 			volume_filename = g_path_get_basename (line + strlen ("Cannot find volume "));
 			error->gerror = g_error_new (FR_ERROR, error->status, _("Could not find the volume: %s"), volume_filename);
 			g_free (volume_filename);
-			break;
+
+			/* RAR7 complains about missing volume for incorrect passwords
+			 * as well, so don't make this a definite error in case we also
+			 * had an incorrect password one earlier */
+			if (! IS_OUTPUT_TYPE (FR_COMMAND_RAR (comm), FR_COMMAND_RAR_TYPE_RAR7))
+				break;
 		}
 	}
 }


### PR DESCRIPTION
RAR 7.0 outputs a different error when password is missing:

>
> Incorrect password for foo.rar
> Incorrect password for foo.rar
> Cannot find volume foo.r00

Whereas RAR 6.21 doesn't output the last 2 lines.

The error about volumes confuses the parser thinking there's a volume issue, which hides the incorrect password one.

Note that RAR 7.0 outputs this *most of the time*, but once in a while it'll also skip the last 2 lines.  Whether it is a race condition or not, it at least happens often enough with RAR 7.0 to consider this its normal behavior and handle it.

Fixes #526.