### PR TITLE
lha: Fix crash, parse lha list output correctly

### DIFF
--- a/src/fr-command-lha.c
+++ b/src/fr-command-lha.c
@@ -149,7 +149,7 @@ split_line_lha (char *line)
 	scan = eat_spaces (scan);
 	for (; i < N_FIELDS; i++) {
 		field_end = strchr (scan, ' ');
-		if (field_end == NULL) {
+		if (field_end == NULL || (i + 1) == N_FIELDS) {
 			field_end = scan + strlen(scan);
 		}
 


### PR DESCRIPTION
The output from the `lha` list archive command is eclectic and inconsistent, and engrampa was actually crashing when opening certain archives (eg. lha_os2_208/h3_subdir.lzh in the Lhasa test suite). But this also fixes the list parsing more generally. With this change, engrampa now appears to successfully open all of the .lzh files in the Lhasa test suite correctly without crashing.

The first field in lha's list output either contains Unix permissions or an OS name in [brackets]. There was already hard-coded support for [MS-DOS], [generic], [unknown] and [Amiga], but other OS names were not handled properly. This is now fixed, with an approach that is mindful of the fact that the OS name can contain spaces.

Empty value (whitespace) in the UID/GID column is also handled correctly.  This was partially working because of the aforementioned special-casing, but now is fixed more generally.

Note this fix has already been merged to [file-roller](https://gitlab.gnome.org/GNOME/file-roller/-/merge_requests/138) and also submitted to lxqt-archiver (lxqt/lxqt-archiver#442).