### PR TITLE
Avoid critical errors with invalid dates

### DIFF
--- a/src/dlg-prop.c
+++ b/src/dlg-prop.c
@@ -101,10 +101,12 @@ dlg_prop (FrWindow *window)
 
 	GDateTime *date_time;
 	date_time = g_date_time_new_from_unix_local (get_file_mtime (fr_window_get_archive_uri (window)));
-	s = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
-	g_date_time_unref (date_time);
-	gtk_label_set_text (GET_LABEL ("p_date_label"), s);
-	g_free (s);
+	if (date_time) {
+		s = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
+		g_date_time_unref (date_time);
+		gtk_label_set_text (GET_LABEL ("p_date_label"), s);
+		g_free (s);
+	}
 
 	/**/
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -1493,8 +1493,12 @@ fr_window_populate_file_list (FrWindow  *window,
 			} else {
 				GDateTime *date_time;
 				date_time = g_date_time_new_from_unix_local (fdata->modified);
-				s_time = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
-				g_date_time_unref (date_time);
+				if (! date_time) {
+					s_time = g_strdup ("");
+				} else {
+					s_time = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
+					g_date_time_unref (date_time);
+				}
 			}
 
 			gtk_list_store_set (window->priv->list_store, &iter,
@@ -1522,8 +1526,12 @@ fr_window_populate_file_list (FrWindow  *window,
 
 			s_size = g_format_size (fdata->size);
 			date_time = g_date_time_new_from_unix_local (fdata->modified);
-			s_time = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
-			g_date_time_unref (date_time);
+			if (! date_time) {
+				s_time = g_strdup("");
+			} else {
+				s_time = g_date_time_format (date_time, _("%d %B %Y, %H:%M"));
+				g_date_time_unref (date_time);
+			}
 			desc = g_content_type_get_description (fdata->content_type);
 
 			gtk_list_store_set (window->priv->list_store, &iter,


### PR DESCRIPTION
This likely should not happen with valid dates, but can if a archiver reports invalid ones for whatever reason (legitimate weird dates, or parser failures for example).

This avoids:
> ```console
> (engrampa:2941602): GLib-CRITICAL **: 11:19:51.953: g_date_time_format: assertion 'datetime != NULL' failed
> 
> (engrampa:2941602): GLib-CRITICAL **: 11:19:51.953: g_date_time_unref: assertion 'datetime != NULL' failed
> ```

when some archivers report randomly absurd dates.  See e.g. [`g_date_time_new_from_unix_local()` documentation](https://docs.gtk.org/glib/ctor.DateTime.new_from_unix_local.html) on how legitimate a failure is (the answer is: entirely).

I encountered this faking more or less random command output when testing out #534, using this script (but it early in `PATH` so it overrides whatever legitimate `lha` there might be on the system):
```sh
#!/bin/sh

cat << EOF
foobar
random stuff that could break a lot of things, right?

empty line above!

[hehe who knew!
[foo bar baz a b c]
lrwxrwxrwx  1000/1000        0 a ****** Feb  3  2013 etc -> ../../etc
-rw-r--r--  1000/1000       12 100.0% Feb  3  2013 etc/passwd
EOF
```