### PR TITLE
fixed wrong drag&drop activation when in single click mode

### DIFF
--- a/src/eggtreemultidnd.c
+++ b/src/eggtreemultidnd.c
@@ -41,10 +41,10 @@ typedef struct
   gint    x;
   gint    y;
   guint   motion_notify_handler;
-  guint   button_release_handler;
   guint   drag_data_get_handler;
   GSList *event_list;
   gboolean pending_event;
+  gboolean button_released;
 } EggTreeMultiDndData;
 
 GType
@@ -178,10 +178,6 @@ stop_drag_check (GtkWidget *widget)
     g_signal_handler_disconnect (widget, priv_data->motion_notify_handler);
     priv_data->motion_notify_handler = 0;
   }
-  if (priv_data->button_release_handler) {
-    g_signal_handler_disconnect (widget, priv_data->button_release_handler);
-    priv_data->button_release_handler = 0;
-  }
 }
 
 static gboolean
@@ -193,6 +189,13 @@ egg_tree_multi_drag_button_release_event (GtkWidget      *widget,
   GSList *l;
 
   priv_data = g_object_get_data (G_OBJECT (widget), EGG_TREE_MULTI_DND_STRING);
+  if (priv_data == NULL)
+    return FALSE;
+
+  priv_data->button_released = TRUE;
+
+  if (! priv_data->pending_event)
+    return FALSE;
 
   for (l = priv_data->event_list; l != NULL; l = l->next)
     gtk_propagate_event (widget, l->data);
@@ -281,6 +284,9 @@ egg_tree_multi_drag_motion_event (GtkWidget      *widget,
   EggTreeMultiDndData *priv_data;
 
   priv_data = g_object_get_data (G_OBJECT (widget), EGG_TREE_MULTI_DND_STRING);
+
+  if (! priv_data->pending_event)
+    return FALSE;
 
   if (gtk_drag_check_threshold (widget,
 				priv_data->x,
@@ -407,10 +413,12 @@ egg_tree_multi_drag_button_press_event (GtkWidget      *widget,
 			      !gtk_tree_selection_path_is_selected (selection, path) ||
 			      event->button != 1);
 
+      /* calling the parent the button_release event could be emitted */
+      priv_data->button_released = FALSE;
       if (call_parent)
 	(GTK_WIDGET_GET_CLASS (tree_view))->button_press_event (widget, event);
 
-      if (gtk_tree_selection_path_is_selected (selection, path))
+      if (! priv_data->button_released && gtk_tree_selection_path_is_selected (selection, path))
     {
       priv_data->pressed_button = event->button;
       priv_data->x = (gint) event->x;
@@ -430,15 +438,6 @@ egg_tree_multi_drag_button_press_event (GtkWidget      *widget,
 			      NULL);
         }
 
-      if (priv_data->button_release_handler == 0)
-        {
-          priv_data->button_release_handler =
-	    g_signal_connect (G_OBJECT (tree_view),
-	 		      "button_release_event",
-			      G_CALLBACK (egg_tree_multi_drag_button_release_event),
-			      NULL);
-        }
-
       if (priv_data->drag_data_get_handler == 0)
 	{
 	  priv_data->drag_data_get_handler =
@@ -449,6 +448,7 @@ egg_tree_multi_drag_button_press_event (GtkWidget      *widget,
 	}
     }
 
+      priv_data->button_released = FALSE;
       gtk_tree_path_free (path);
       /* We called the default handler so we don't let the default handler run */
       return TRUE;
@@ -464,6 +464,10 @@ egg_tree_multi_drag_add_drag_support (GtkTreeView *tree_view)
   g_signal_connect (G_OBJECT (tree_view),
 		    "button_press_event",
 		    G_CALLBACK (egg_tree_multi_drag_button_press_event),
+		    NULL);
+  g_signal_connect (G_OBJECT (tree_view),
+		    "button_release_event",
+		    G_CALLBACK (egg_tree_multi_drag_button_release_event),
 		    NULL);
 }
 

--- a/src/fr-window.c
+++ b/src/fr-window.c
@@ -4153,6 +4153,11 @@ file_list_drag_begin (GtkWidget          *widget,
 	if (window->priv->activity_ref > 0)
 		return FALSE;
 
+	if (window->priv->path_clicked != NULL) {
+		gtk_tree_path_free (window->priv->path_clicked);
+		window->priv->path_clicked = NULL;
+	}
+
 	g_free (window->priv->drag_destination_folder);
 	window->priv->drag_destination_folder = NULL;
 


### PR DESCRIPTION
when calling the parent button_press_event function a button released event could be emitted, in that case stop the drag&drop action.

Backported from https://gitlab.gnome.org/GNOME/file-roller/-/commit/279b76d6

Fixes #547