### PR TITLE
fr-command-rpm: prevent path traversal when extracting RPM archives

### DIFF
--- a/.github/workflows/builds.sh
+++ b/.github/workflows/builds.sh
@@ -58,6 +58,14 @@ if [ -f autogen.sh ]; then
 	}
 	infoend
 
+	infobegin "CVE-2023-52138 regression test"
+	if [ -f tests/test-cve-2023-52138.sh ]; then
+		bash tests/test-cve-2023-52138.sh
+	else
+		echo "tests/test-cve-2023-52138.sh not found, skipping"
+	fi
+	infoend
+
 	infobegin "Distcheck (autotools)"
 	make -j ${CPUS} distcheck
 	infoend

--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,8 @@ EXTRA_DIST += \
 	po/meson.build			\
 	src/meson.build			\
 	src/sh/meson.build		\
-	subprojects/mate-submodules.wrap
+	subprojects/mate-submodules.wrap	\
+	tests/test-cve-2023-52138.sh
 
 DISTCLEANFILES =
 

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,14 @@ endif
 subdir('po')
 subdir('src')
 
+# Regression test for CVE-2023-52138 (cpio extraction path traversal)
+# Run with: ninja -C _build test
+test_script = files('tests/test-cve-2023-52138.sh')
+test('cve-2023-52138',
+     find_program('bash', 'sh'),
+     args : [test_script],
+     timeout : 120)
+
 # Summary
 
 summary = [

--- a/src/fr-command-rpm.c
+++ b/src/fr-command-rpm.c
@@ -208,7 +208,7 @@ fr_command_rpm_extract (FrCommand  *comm,
 
 	cmd = g_string_new ("rpm2cpio < ");
 	g_string_append (cmd, comm->e_filename);
-	g_string_append (cmd, " | cpio -idu");
+	g_string_append (cmd, " | cpio -idu --no-absolute-filenames");
 	for (scan = file_list; scan; scan = scan->next) {
 		g_string_append (cmd, " ");
 		char *filename = g_shell_quote (scan->data);

--- a/tests/test-cve-2023-52138.sh
+++ b/tests/test-cve-2023-52138.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+# test-cve-2023-52138.sh
+#
+# Regression test for CVE-2023-52138: cpio extraction path traversal.
+#
+# Background: upstream commit 63d5dfa added --no-absolute-filenames to
+# the extraction command in fr-command-cpio.c; this patch (PR #553)
+# adds the same flag to the rpm2cpio | cpio pipeline in fr-command-rpm.c.
+#
+# This script mimics the extraction commands engrampa actually runs,
+# crafting malicious cpio payloads (absolute-path and ../ entries) and
+# asserting:
+#   0. source static check: both extraction paths must carry the flag
+#   1. without the flag (cpio -idu)   -> files written outside the
+#                                        extraction dir (vulnerability)
+#   2. with the flag (cpio -idu --no-absolute-filenames)
+#                                    -> files stay inside the
+#                                       extraction dir (fix)
+#   3. full rpm2cpio | cpio pipeline (fixed) extracts a normal RPM
+#      without regression
+
+set -u
+WORK=$(mktemp -d /tmp/engrampa-cve-test.XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+
+# Source root (the script lives in tests/)
+SRC_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+
+ok()   { echo "  [PASS] $1"; PASS=$((PASS+1)); }
+bad()  { echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+# ---------- Test 0: source static check ----------
+echo "== Test 0: source extraction paths must carry --no-absolute-filenames =="
+if grep -q -- "--no-absolute-filenames" "$SRC_ROOT/src/fr-command-cpio.c"; then
+    ok "fr-command-cpio.c extraction path carries the flag"
+else
+    bad "fr-command-cpio.c is missing the flag (upstream fix reverted?)"
+fi
+if grep -q -- "--no-absolute-filenames" "$SRC_ROOT/src/fr-command-rpm.c"; then
+    ok "fr-command-rpm.c extraction path carries the flag"
+else
+    bad "fr-command-rpm.c is missing the flag (this patch ineffective?)"
+fi
+echo
+
+# ---------- Tool check ----------
+if ! command -v cpio >/dev/null 2>&1; then
+    echo "  [SKIP] cpio not found; skipping dynamic tests (1-5), source static check only"
+    echo
+    echo "========== RESULT: PASS=$PASS FAIL=$FAIL (static check) =========="
+    [ "$FAIL" -eq 0 ]
+    exit
+fi
+
+# ---------- Build malicious payloads ----------
+echo "== Building malicious cpio payloads =="
+
+# Payload 1: absolute-path entry  /tmp/.../evil.txt
+mkdir -p "$WORK/src-abs"
+echo "PWNED-ABS" > "$WORK/src-abs/evil.txt"
+(cd / && find "$WORK/src-abs" -print | cpio -o -H newc 2>/dev/null) > "$WORK/evil-abs.cpio"
+
+# Payload 2: ../ traversal entry  ../evil.txt
+mkdir -p "$WORK/stage/sub"
+echo "PWNED-DOTDOT" > "$WORK/stage/evil.txt"
+(cd "$WORK/stage/sub" && printf '../evil.txt\n' | cpio -o -H newc 2>/dev/null) > "$WORK/evil-dotdot.cpio"
+
+echo "  Payload 1 entries: $(cpio -it < "$WORK/evil-abs.cpio" 2>/dev/null | tr '\n' ' ')"
+echo "  Payload 2 entries: $(cpio -it < "$WORK/evil-dotdot.cpio" 2>/dev/null | tr '\n' ' ')"
+
+# ---------- Test 1: absolute path, without flag (vulnerability) ----------
+echo "== Test 1: absolute-path entry + cpio -idu (no flag) =="
+DEST="$WORK/dest-abs-vuln"; mkdir -p "$DEST"
+rm -f "$WORK/src-abs/evil.txt"   # delete the source file to avoid false positives
+( cd "$DEST" && cpio -idu < "$WORK/evil-abs.cpio" >/dev/null 2>&1 )
+if [ -f "$WORK/src-abs/evil.txt" ]; then
+    ok "malicious file written to absolute location $WORK/src-abs/evil.txt (vulnerability reproduced)"
+else
+    bad "no out-of-directory write detected (unexpected)"
+fi
+
+# ---------- Test 2: absolute path, with flag (fix verification) ----------
+echo "== Test 2: absolute-path entry + cpio -idu --no-absolute-filenames =="
+DEST="$WORK/dest-abs-fixed"; mkdir -p "$DEST"
+rm -f "$WORK/src-abs/evil.txt"
+( cd "$DEST" && cpio -idu --no-absolute-filenames < "$WORK/evil-abs.cpio" >/dev/null 2>&1 )
+if [ ! -e "$WORK/src-abs/evil.txt" ]; then
+    ok "absolute location not written"
+else
+    bad "absolute location written (fix ineffective)"
+fi
+if [ -f "$DEST/$WORK/src-abs/evil.txt" ]; then
+    ok "file lands inside the extraction dir: $DEST/$WORK/src-abs/evil.txt"
+else
+    bad "file not found inside the extraction dir"
+fi
+
+# ---------- Test 3: ../ traversal, without flag ----------
+echo "== Test 3: ../ traversal entry + cpio -idu (no flag) =="
+DEST="$WORK/dest-dot-vuln"; mkdir -p "$DEST"
+# the payload entry is ../evil.txt; extracted from $DEST, ../ resolves to $WORK
+rm -f "$WORK/evil.txt" "$WORK/stage/evil.txt"
+( cd "$DEST" && cpio -idu < "$WORK/evil-dotdot.cpio" >/dev/null 2>&1 )
+if [ -f "$WORK/evil.txt" ]; then
+    ok "malicious file written to parent dir $WORK/evil.txt (vulnerability reproduced)"
+else
+    bad "no ../ out-of-directory write detected (unexpected)"
+fi
+
+# ---------- Test 4: ../ traversal, with flag ----------
+echo "== Test 4: ../ traversal entry + cpio -idu --no-absolute-filenames =="
+DEST="$WORK/dest-dot-fixed"; mkdir -p "$DEST"
+rm -f "$WORK/evil.txt" "$WORK/stage/evil.txt"
+( cd "$DEST" && cpio -idu --no-absolute-filenames < "$WORK/evil-dotdot.cpio" >/dev/null 2>&1 )
+# verified: GNU cpio's --no-absolute-filenames also strips the ../ prefix,
+# so files stay inside the extraction dir and cannot escape.
+if [ ! -e "$WORK/evil.txt" ]; then
+    ok "parent dir not written (../ prefix stripped)"
+else
+    bad "parent dir written (fix ineffective)"
+fi
+if [ -f "$DEST/evil.txt" ]; then
+    ok "file lands inside the extraction dir: $DEST/evil.txt"
+else
+    bad "file not found inside the extraction dir"
+fi
+
+# ---------- Test 5: full rpm2cpio | cpio pipeline (fixed), normal RPM ----------
+echo "== Test 5: rpm2cpio | cpio -idu --no-absolute-filenames extracts a normal RPM =="
+if command -v rpmbuild >/dev/null 2>&1; then
+    RPDIR="$WORK/rpmbuild"
+    # create each directory explicitly (POSIX-compatible; brace expansion
+    # is a bash feature, unsupported in dash/sh)
+    mkdir -p "$RPDIR/BUILD" "$RPDIR/RPMS" "$RPDIR/SOURCES" "$RPDIR/SPECS" "$RPDIR/SRPMS"
+    cat > "$RPDIR/SPECS/test.spec" <<'EOF'
+Name:           engrampa-cve-test
+Version:        1.0
+Release:        1
+Summary:        regression test
+License:        GPLv2+
+BuildArch:      noarch
+%description
+Regression test payload for CVE-2023-52138.
+%prep
+%build
+%install
+mkdir -p %{buildroot}/usr/share/engrampa-cve-test
+echo "ok" > %{buildroot}/usr/share/engrampa-cve-test/hello.txt
+%files
+/usr/share/engrampa-cve-test/hello.txt
+EOF
+    if rpmbuild --define "_topdir $RPDIR" -bb "$RPDIR/SPECS/test.spec" >/dev/null 2>&1; then
+        RPMFILE=$(find "$RPDIR/RPMS" -name '*.rpm' | head -1)
+        DEST="$WORK/dest-rpm"; mkdir -p "$DEST"
+        ( cd "$DEST" && rpm2cpio < "$RPMFILE" | cpio -idu --no-absolute-filenames >/dev/null 2>&1 )
+        if [ -f "$DEST/usr/share/engrampa-cve-test/hello.txt" ]; then
+            ok "normal RPM extracted successfully (no regression with the flag)"
+        else
+            bad "normal RPM extraction failed"
+        fi
+    else
+        echo "  [SKIP] rpmbuild failed to build the test RPM, skipping test 5"
+    fi
+else
+    echo "  [SKIP] rpmbuild not found, skipping test 5"
+fi
+
+echo
+echo "========== RESULT: PASS=$PASS FAIL=$FAIL =========="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
CVE-2023-52138 fixes path traversal via crafted cpio archives by adding --no-absolute-filenames to the cpio extraction command in fr-command-cpio.c (commit 63d5dfa).  However the same vulnerability still exists in the RPM extraction path, which pipes rpm2cpio output into 'cpio -idu' without that flag.  A crafted RPM whose cpio payload contains absolute paths can therefore write files outside the extraction directory (e.g. ~/.ssh, ~/.bashrc).

Add the same --no-absolute-filenames flag to the rpm2cpio | cpio pipeline to close the gap.